### PR TITLE
Escape $ in longchat article properly

### DIFF
--- a/blog/2023-06-29-longchat.md
+++ b/blog/2023-06-29-longchat.md
@@ -70,7 +70,7 @@ After condensing the embedding, we perform the finetuning procedure on our curat
 We reuse our collected user-shared conversations previously used for training Vicuna. 
 We clean the data using FastChat data pipeline, and truncate these conversations so they are no longer than 16K. 
 We finetune the model using standard next-token prediction loss. We fine-tune the 7B and 13B models with 80k and 18k conversations, respectively. 
-To save memory, we use Pytorch FSDP and Flash Attention. Assume A100 is $3/hour on Cloud, the 7B model costs ~$300, and the 13B model costs ~$700. 
+To save memory, we use Pytorch FSDP and Flash Attention. Assume A100 is \\$3/hour on Cloud, the 7B model costs ~\\$300, and the 13B model costs ~\\$700. 
 
 ## Evaluation toolkits: LongEval
 Recently, commercial and open-source models have continued to tout their abilities to support expanded context length (from 8K, 32K, 84K, to 100K) in their latest releases, but how can we verify these claims?


### PR DESCRIPTION
The `$` characters in [this article](https://lmsys.org/blog/2023-06-29-longchat/) used as currency symbols are not escaped, so they get interpreted as a mathematical expression.

Before:
![image](https://github.com/lm-sys/lm-sys.github.io/assets/173636334/6fed4b11-b5a8-4a85-99ad-8ea5dbfee055)

After:
![image](https://github.com/lm-sys/lm-sys.github.io/assets/173636334/55e8df9a-9e30-4ad1-a10e-a031fd3c097c)
