### PR TITLE
Add DSpark draft model link in Kimi K3 blog highlights

### DIFF
--- a/blog/2026-07-27-kimi-k3-day0-support.md
+++ b/blog/2026-07-27-kimi-k3-day0-support.md
@@ -23,7 +23,7 @@ it took.
   overwrites itself in place, with prefix caching, overlap scheduling and paging rebuilt
   on top, and a unified pool design that removes the last sizing guess.
 - **A kernel ladder** reaching ~113 tok/s at batch 1, before speculation.
-- **DSpark speculative decoding, with a draft model we trained for K3**: batch-1 decode
+- **DSpark speculative decoding, with [a draft model we trained for K3](https://huggingface.co/RadixArk/Kimi-K3-DSpark)**: batch-1 decode
   reaches ~423 tok/s. ReplaySSM handles the KDA state, replaying raw inputs instead of
   snapshotting per step, a roughly 32x cut in draft-window memory.
 - **Parallelism split by phase**: chunked pipeline-parallel prefill and context-parallel


### PR DESCRIPTION
Link the DSpark draft model in the highlights bullet of the Kimi K3 day-0 blog post.