### PR TITLE
Update Kimi K3 serving frontier with additional raw datapoints

### DIFF
--- a/blog/2026-07-27-kimi-k3-day0-support.md
+++ b/blog/2026-07-27-kimi-k3-day0-support.md
@@ -413,19 +413,20 @@ the memory section above takes that on.
 ### Combining all strategies together
 
 How the pieces compose is ultimately a measurement. Putting PD disaggregation in the
-loop, with chunked PP8 prefill throughout and the decode topology and prefill:decode
-ratio varying, gives the serving frontier:
+loop, with the prefill topology, decode topology and prefill:decode ratio varying, gives
+the serving frontier:
 
 <p align="center">
-  <img src="/images/blog/kimi-k3-day0-support/fig-pareto-pd.svg" width="98%" alt="K3 serving frontier under PD disaggregation: total throughput per GPU versus per-user decode speed for chunked PP8 prefill feeding TP8, DCP8, EP and multi-instance TP8 decode arms; the frontier runs from PP8 to TP8 at the throughput end out to PP8 feeding four TP8 instances at the interactive end.">
+  <img src="/images/blog/kimi-k3-day0-support/fig-pareto-pd.svg" width="98%" alt="K3 serving frontier under PD disaggregation: total throughput per GPU versus per-user decode speed for PP8 and TP8 prefill feeding TP8, DCP8, EP and multi-instance TP8 decode arms; the frontier runs from PP8 to TP8 at the throughput end out to TP8 feeding three TP8 instances at the interactive end.">
 </p>
 
 <p align="center">
-  <em><b>The serving frontier.</b> At the throughput end the DCP composition, two PP8
-  prefill workers feeding two DCP8 decode nodes, delivers 2,633 tok/s per GPU, level with
-  the best TP8 arm. Moving right is the prefill:decode knob at work: one PP8 prefill
-  worker feeding two, three, then four independent TP8 decode instances trades aggregate
-  throughput for per-user speed, out past 86 tok/s per user.</em>
+  <em><b>The serving frontier.</b> At the throughput end one PP8 prefill worker feeding
+  one TP8 decode node delivers 2,808 tok/s per GPU on the fp4 arm, with the DCP
+  composition, two PP8 prefill workers feeding two DCP8 decode nodes, just behind at
+  2,633. Moving right is the prefill:decode knob at work: one prefill worker feeding two,
+  three, then four independent decode instances trades aggregate throughput for per-user
+  speed, out past 116 tok/s per user.</em>
 </p>
 
 ## RL: LoRA Training on the Native MXFP4 Base

--- a/public/images/blog/kimi-k3-day0-support/fig-pareto-pd.svg
+++ b/public/images/blog/kimi-k3-day0-support/fig-pareto-pd.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="871.457344pt" height="474.507pt" viewBox="0 0 871.457344 474.507" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1023.582091pt" height="439.488769pt" viewBox="0 0 1023.582091 439.488769" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-27T07:16:21.319195</dc:date>
+    <dc:date>2026-07-27T12:35:22.988920</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.9.4, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,35 +21,35 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 474.507 
-L 871.457344 474.507 
-L 871.457344 0 
+   <path d="M 0 439.488769 
+L 1023.582091 439.488769 
+L 1023.582091 0 
 L 0 0 
 z
 " style="fill: #fcfcfb"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 56.7352 394.3955 
-L 793.1232 394.3955 
-L 793.1232 52.3125 
-L 56.7352 52.3125 
+    <path d="M 53.1648 386.107969 
+L 834.3648 386.107969 
+L 834.3648 43.387969 
+L 53.1648 43.387969 
 z
 " style="fill: #fcfcfb"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 73.66366 394.3955 
-L 73.66366 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 79.646156 386.107969 
+L 79.646156 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- 10 -->
-      <g style="fill: #52514e" transform="translate(67.826316 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(73.808812 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-18" d="M 2278 0 
+        <path id="HelveticaNeue-31" d="M 2278 0 
 L 2278 4538 
 L 1862 4538 
 Q 1818 4282 1696 4115 
@@ -62,7 +62,7 @@ L 1734 0
 L 2278 0 
 z
 " transform="scale(0.015625)"/>
-        <path id="HelveticaNeue-17" d="M 845 2234 
+        <path id="HelveticaNeue-30" d="M 845 2234 
 Q 845 2400 848 2601 
 Q 851 2803 880 3004 
 Q 909 3206 963 3398 
@@ -112,23 +112,23 @@ Q 269 2477 269 2227
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-18"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 158.305959 394.3955 
-L 158.305959 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 145.849546 386.107969 
+L 145.849546 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- 20 -->
-      <g style="fill: #52514e" transform="translate(152.468615 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(140.012202 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-19" d="M 282 2931 
+        <path id="HelveticaNeue-32" d="M 282 2931 
 L 826 2931 
 Q 819 3136 867 3337 
 Q 915 3539 1024 3699 
@@ -168,23 +168,23 @@ Q 262 3277 282 2931
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-19"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-32"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 242.948257 394.3955 
-L 242.948257 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 212.052936 386.107969 
+L 212.052936 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- 30 -->
-      <g style="fill: #52514e" transform="translate(237.110914 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(206.215592 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1a" d="M 1395 2592 
+        <path id="HelveticaNeue-33" d="M 1395 2592 
 L 1395 2131 
 Q 1549 2150 1722 2150 
 Q 1926 2150 2102 2096 
@@ -236,23 +236,23 @@ Q 1427 2586 1395 2592
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1a"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-33"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 327.590556 394.3955 
-L 327.590556 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 278.256325 386.107969 
+L 278.256325 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
       <!-- 40 -->
-      <g style="fill: #52514e" transform="translate(321.753213 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(272.418982 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1b" d="M 2170 1542 
+        <path id="HelveticaNeue-34" d="M 2170 1542 
 L 646 1542 
 L 2157 3763 
 L 2170 3763 
@@ -273,23 +273,23 @@ L 2682 1542
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1b"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-34"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 412.232855 394.3955 
-L 412.232855 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 344.459715 386.107969 
+L 344.459715 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
       <!-- 50 -->
-      <g style="fill: #52514e" transform="translate(406.395511 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(338.622372 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1c" d="M 3008 3981 
+        <path id="HelveticaNeue-35" d="M 3008 3981 
 L 3008 4461 
 L 768 4461 
 L 346 2106 
@@ -329,23 +329,23 @@ L 3008 3981
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1c"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-35"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 496.875154 394.3955 
-L 496.875154 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 410.663105 386.107969 
+L 410.663105 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
       <!-- 60 -->
-      <g style="fill: #52514e" transform="translate(491.03781 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(404.825761 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1d" d="M 2650 3379 
+        <path id="HelveticaNeue-36" d="M 2650 3379 
 L 3194 3379 
 Q 3142 3942 2809 4240 
 Q 2477 4538 1914 4538 
@@ -395,23 +395,23 @@ Q 1600 2438 1830 2438
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1d"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-36"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 581.517453 394.3955 
-L 581.517453 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 476.866495 386.107969 
+L 476.866495 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
       <!-- 70 -->
-      <g style="fill: #52514e" transform="translate(575.680109 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(471.029151 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1e" d="M 3258 3994 
+        <path id="HelveticaNeue-37" d="M 3258 3994 
 L 3258 4461 
 L 320 4461 
 L 320 3949 
@@ -428,23 +428,23 @@ Q 2912 3654 3258 3994
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1e"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-37"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 666.159752 394.3955 
-L 666.159752 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 543.069885 386.107969 
+L 543.069885 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
       <!-- 80 -->
-      <g style="fill: #52514e" transform="translate(660.322408 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(537.232541 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-1f" d="M 992 3360 
+        <path id="HelveticaNeue-38" d="M 992 3360 
 Q 992 3533 1056 3661 
 Q 1120 3789 1225 3878 
 Q 1331 3968 1478 4013 
@@ -502,23 +502,23 @@ Q 832 870 832 1280
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-1f"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-38"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 750.802051 394.3955 
-L 750.802051 52.3125 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+      <path d="M 609.273275 386.107969 
+L 609.273275 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
       <!-- 90 -->
-      <g style="fill: #52514e" transform="translate(744.964707 407.8915) scale(0.105 -0.105)">
+      <g style="fill: #52514e" transform="translate(603.435931 397.105625) scale(0.105 -0.105)">
        <defs>
-        <path id="HelveticaNeue-20" d="M 858 1094 
+        <path id="HelveticaNeue-39" d="M 858 1094 
 L 314 1094 
 Q 365 506 742 218 
 Q 1120 -70 1690 -70 
@@ -564,16 +564,64 @@ Q 2618 3232 2618 3021
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#HelveticaNeue-20"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
+       <use xlink:href="#HelveticaNeue-39"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
       </g>
      </g>
     </g>
-    <g id="text_10">
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 675.476664 386.107969 
+L 675.476664 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20"/>
+     <g id="text_10">
+      <!-- 100 -->
+      <g style="fill: #52514e" transform="translate(666.720649 397.105625) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 741.680054 386.107969 
+L 741.680054 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22"/>
+     <g id="text_11">
+      <!-- 110 -->
+      <g style="fill: #52514e" transform="translate(732.924039 397.105625) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-31" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 807.883444 386.107969 
+L 807.883444 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24"/>
+     <g id="text_12">
+      <!-- 120 -->
+      <g style="fill: #52514e" transform="translate(799.127428 397.105625) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-32" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
      <!-- per-user decode speed (tok/s/user = 1000 / TPOT p50) -->
-     <g style="fill: #1a1b1d" transform="translate(290.104434 429.6) scale(0.11 -0.11)">
+     <g style="fill: #52514e" transform="translate(308.940034 416.214766) scale(0.11 -0.11)">
       <defs>
-       <path id="HelveticaNeue-57" d="M 429 3309 
+       <path id="HelveticaNeue-70" d="M 429 3309 
 L 429 -1261 
 L 973 -1261 
 L 973 442 
@@ -615,7 +663,7 @@ Q 2867 2355 2928 2134
 Q 2989 1914 2989 1683 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-4c" d="M 2707 1971 
+       <path id="HelveticaNeue-65" d="M 2707 1971 
 L 806 1971 
 Q 819 2163 889 2332 
 Q 960 2502 1081 2630 
@@ -651,7 +699,7 @@ Q 2381 -70 2752 211
 Q 3123 493 3232 1050 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-59" d="M 390 3309 
+       <path id="HelveticaNeue-72" d="M 390 3309 
 L 390 0 
 L 934 0 
 L 934 1472 
@@ -667,14 +715,14 @@ L 902 3309
 L 390 3309 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-14" d="M 320 2035 
+       <path id="HelveticaNeue-2d" d="M 320 2035 
 L 320 1523 
 L 2170 1523 
 L 2170 2035 
 L 320 2035 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-5c" d="M 3149 0 
+       <path id="HelveticaNeue-75" d="M 3149 0 
 L 3149 3309 
 L 2605 3309 
 L 2605 1440 
@@ -698,7 +746,7 @@ L 2637 0
 L 3149 0 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-5a" d="M 742 1043 
+       <path id="HelveticaNeue-73" d="M 742 1043 
 L 198 1043 
 Q 211 736 326 521 
 Q 442 307 634 176 
@@ -749,8 +797,8 @@ Q 902 614 825 739
 Q 749 864 742 1043 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-3" transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-4b" d="M 806 1626 
+       <path id="HelveticaNeue-20" transform="scale(0.015625)"/>
+       <path id="HelveticaNeue-64" d="M 806 1626 
 Q 806 1869 857 2099 
 Q 909 2330 1024 2509 
 Q 1139 2688 1331 2797 
@@ -792,7 +840,7 @@ L 2822 0
 L 3366 0 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-4a" d="M 2656 2246 
+       <path id="HelveticaNeue-63" d="M 2656 2246 
 L 3219 2246 
 Q 3187 2541 3065 2755 
 Q 2944 2970 2755 3110 
@@ -823,7 +871,7 @@ Q 2182 2906 2387 2733
 Q 2592 2560 2656 2246 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-56" d="M 806 1651 
+       <path id="HelveticaNeue-6f" d="M 806 1651 
 Q 806 1952 886 2185 
 Q 966 2419 1107 2579 
 Q 1248 2739 1437 2822 
@@ -860,7 +908,7 @@ Q 435 2650 332 2333
 Q 230 2016 230 1651 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-f" d="M 1306 -1261 
+       <path id="HelveticaNeue-28" d="M 1306 -1261 
 L 1722 -1261 
 Q 1267 -525 1072 198 
 Q 877 922 877 1728 
@@ -875,7 +923,7 @@ Q 704 -192 889 -547
 Q 1075 -902 1306 -1261 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-5b" d="M 1165 3309 
+       <path id="HelveticaNeue-74" d="M 1165 3309 
 L 1165 4301 
 L 621 4301 
 L 621 3309 
@@ -900,7 +948,7 @@ L 1824 3309
 L 1165 3309 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-52" d="M 442 4570 
+       <path id="HelveticaNeue-6b" d="M 442 4570 
 L 442 0 
 L 986 0 
 L 986 1254 
@@ -915,14 +963,14 @@ L 986 4570
 L 442 4570 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-16" d="M 1779 4678 
+       <path id="HelveticaNeue-2f" d="M 1779 4678 
 L -109 -102 
 L 352 -102 
 L 2246 4678 
 L 1779 4678 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-24" d="M 307 1190 
+       <path id="HelveticaNeue-3d" d="M 307 1190 
 L 307 755 
 L 3533 755 
 L 3533 1190 
@@ -935,7 +983,7 @@ L 307 2048
 L 3533 2048 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-3b" d="M 1536 4058 
+       <path id="HelveticaNeue-54" d="M 1536 4058 
 L 1536 0 
 L 2144 0 
 L 2144 4058 
@@ -946,7 +994,7 @@ L 13 4058
 L 1536 4058 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-37" d="M 1107 2381 
+       <path id="HelveticaNeue-50" d="M 1107 2381 
 L 1107 4058 
 L 2298 4058 
 Q 2816 4058 3056 3843 
@@ -967,7 +1015,7 @@ Q 3194 4570 2502 4570
 L 499 4570 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-36" d="M 851 2285 
+       <path id="HelveticaNeue-4f" d="M 851 2285 
 Q 851 2630 940 2966 
 Q 1030 3302 1222 3571 
 Q 1414 3840 1715 4003 
@@ -1004,7 +1052,7 @@ Q 518 3616 380 3184
 Q 243 2752 243 2285 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-10" d="M -58 -1261 
+       <path id="HelveticaNeue-29" d="M -58 -1261 
 L 352 -1261 
 Q 851 -602 1104 163 
 Q 1357 928 1357 1683 
@@ -1020,165 +1068,182 @@ Q 397 -538 -58 -1261
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#HelveticaNeue-57"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(59.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(113 0)"/>
-      <use xlink:href="#HelveticaNeue-14" transform="translate(140.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-5c" transform="translate(179.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-5a" transform="translate(235.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(285.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(339 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(372.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-4b" transform="translate(400.09375 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(459.390625 0)"/>
-      <use xlink:href="#HelveticaNeue-4a" transform="translate(513.09375 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(566.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-4b" transform="translate(624.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(683.5 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(737.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-5a" transform="translate(765 0)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(815 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(874.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(928 0)"/>
-      <use xlink:href="#HelveticaNeue-4b" transform="translate(981.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1041 0)"/>
-      <use xlink:href="#HelveticaNeue-f" transform="translate(1068.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(1094.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(1126.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-52" transform="translate(1183.609375 0)"/>
-      <use xlink:href="#HelveticaNeue-16" transform="translate(1235.515625 0)"/>
-      <use xlink:href="#HelveticaNeue-5a" transform="translate(1268.8125 0)"/>
-      <use xlink:href="#HelveticaNeue-16" transform="translate(1318.8125 0)"/>
-      <use xlink:href="#HelveticaNeue-5c" transform="translate(1352.109375 0)"/>
-      <use xlink:href="#HelveticaNeue-5a" transform="translate(1407.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(1457.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(1511.40625 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1544.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-24" transform="translate(1572.5 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1632.5 0)"/>
-      <use xlink:href="#HelveticaNeue-18" transform="translate(1660.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-17" transform="translate(1715.890625 0)"/>
-      <use xlink:href="#HelveticaNeue-17" transform="translate(1771.484375 0)"/>
-      <use xlink:href="#HelveticaNeue-17" transform="translate(1827.078125 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1882.671875 0)"/>
-      <use xlink:href="#HelveticaNeue-16" transform="translate(1910.46875 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1943.765625 0)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(1971.5625 0)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(2028.96875 0)"/>
-      <use xlink:href="#HelveticaNeue-36" transform="translate(2093.765625 0)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(2169.765625 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(2227.171875 0)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(2254.96875 0)"/>
-      <use xlink:href="#HelveticaNeue-1c" transform="translate(2314.265625 0)"/>
-      <use xlink:href="#HelveticaNeue-17" transform="translate(2369.859375 0)"/>
-      <use xlink:href="#HelveticaNeue-10" transform="translate(2425.453125 0)"/>
+      <use xlink:href="#HelveticaNeue-70"/>
+      <use xlink:href="#HelveticaNeue-65" x="59.299988"/>
+      <use xlink:href="#HelveticaNeue-72" x="112.999985"/>
+      <use xlink:href="#HelveticaNeue-2d" x="140.799973"/>
+      <use xlink:href="#HelveticaNeue-75" x="179.699966"/>
+      <use xlink:href="#HelveticaNeue-73" x="235.299957"/>
+      <use xlink:href="#HelveticaNeue-65" x="285.299942"/>
+      <use xlink:href="#HelveticaNeue-72" x="338.999939"/>
+      <use xlink:href="#HelveticaNeue-20" x="372.299927"/>
+      <use xlink:href="#HelveticaNeue-64" x="400.099915"/>
+      <use xlink:href="#HelveticaNeue-65" x="459.399902"/>
+      <use xlink:href="#HelveticaNeue-63" x="513.099899"/>
+      <use xlink:href="#HelveticaNeue-6f" x="566.799896"/>
+      <use xlink:href="#HelveticaNeue-64" x="624.19989"/>
+      <use xlink:href="#HelveticaNeue-65" x="683.499878"/>
+      <use xlink:href="#HelveticaNeue-20" x="737.199875"/>
+      <use xlink:href="#HelveticaNeue-73" x="764.999863"/>
+      <use xlink:href="#HelveticaNeue-70" x="814.999847"/>
+      <use xlink:href="#HelveticaNeue-65" x="874.299835"/>
+      <use xlink:href="#HelveticaNeue-65" x="927.999832"/>
+      <use xlink:href="#HelveticaNeue-64" x="981.699829"/>
+      <use xlink:href="#HelveticaNeue-20" x="1040.999817"/>
+      <use xlink:href="#HelveticaNeue-28" x="1068.799805"/>
+      <use xlink:href="#HelveticaNeue-74" x="1094.699799"/>
+      <use xlink:href="#HelveticaNeue-6f" x="1126.199783"/>
+      <use xlink:href="#HelveticaNeue-6b" x="1183.599777"/>
+      <use xlink:href="#HelveticaNeue-2f" x="1235.499771"/>
+      <use xlink:href="#HelveticaNeue-73" x="1268.799759"/>
+      <use xlink:href="#HelveticaNeue-2f" x="1318.799744"/>
+      <use xlink:href="#HelveticaNeue-75" x="1352.099731"/>
+      <use xlink:href="#HelveticaNeue-73" x="1407.699722"/>
+      <use xlink:href="#HelveticaNeue-65" x="1457.699707"/>
+      <use xlink:href="#HelveticaNeue-72" x="1511.399704"/>
+      <use xlink:href="#HelveticaNeue-20" x="1544.699692"/>
+      <use xlink:href="#HelveticaNeue-3d" x="1572.49968"/>
+      <use xlink:href="#HelveticaNeue-20" x="1632.499664"/>
+      <use xlink:href="#HelveticaNeue-31" x="1660.299652"/>
+      <use xlink:href="#HelveticaNeue-30" x="1715.899643"/>
+      <use xlink:href="#HelveticaNeue-30" x="1771.499634"/>
+      <use xlink:href="#HelveticaNeue-30" x="1827.099625"/>
+      <use xlink:href="#HelveticaNeue-20" x="1882.699615"/>
+      <use xlink:href="#HelveticaNeue-2f" x="1910.499603"/>
+      <use xlink:href="#HelveticaNeue-20" x="1943.799591"/>
+      <use xlink:href="#HelveticaNeue-54" x="1971.599579"/>
+      <use xlink:href="#HelveticaNeue-50" x="2028.999573"/>
+      <use xlink:href="#HelveticaNeue-4f" x="2093.799561"/>
+      <use xlink:href="#HelveticaNeue-54" x="2169.799545"/>
+      <use xlink:href="#HelveticaNeue-20" x="2227.199539"/>
+      <use xlink:href="#HelveticaNeue-70" x="2254.999527"/>
+      <use xlink:href="#HelveticaNeue-35" x="2314.299515"/>
+      <use xlink:href="#HelveticaNeue-30" x="2369.899506"/>
+      <use xlink:href="#HelveticaNeue-29" x="2425.499496"/>
      </g>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_19">
-      <path d="M 56.7352 394.3955 
-L 793.1232 394.3955 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_25">
+      <path d="M 53.1648 386.107969 
+L 834.3648 386.107969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_20"/>
-     <g id="text_11">
+     <g id="line2d_26"/>
+     <g id="text_14">
       <!-- 0 -->
-      <g style="fill: #52514e" transform="translate(47.397856 399.3935) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-17"/>
+      <g style="fill: #52514e" transform="translate(43.827456 389.856797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_21">
-      <path d="M 56.7352 336.415331 
-L 793.1232 336.415331 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_27">
+      <path d="M 53.1648 328.987969 
+L 834.3648 328.987969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_22"/>
-     <g id="text_12">
+     <g id="line2d_28"/>
+     <g id="text_15">
       <!-- 500 -->
-      <g style="fill: #52514e" transform="translate(35.723169 341.413331) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-1c"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(111.1875 0)"/>
+      <g style="fill: #52514e" transform="translate(32.152769 332.736797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-35"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_23">
-      <path d="M 56.7352 278.435161 
-L 793.1232 278.435161 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_29">
+      <path d="M 53.1648 271.867969 
+L 834.3648 271.867969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_24"/>
-     <g id="text_13">
+     <g id="line2d_30"/>
+     <g id="text_16">
       <!-- 1000 -->
-      <g style="fill: #52514e" transform="translate(29.885825 283.433161) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-18"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(111.1875 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(166.78125 0)"/>
+      <g style="fill: #52514e" transform="translate(26.315425 275.616797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+       <use xlink:href="#HelveticaNeue-30" x="166.799973"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_25">
-      <path d="M 56.7352 220.454992 
-L 793.1232 220.454992 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_31">
+      <path d="M 53.1648 214.747969 
+L 834.3648 214.747969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_26"/>
-     <g id="text_14">
+     <g id="line2d_32"/>
+     <g id="text_17">
       <!-- 1500 -->
-      <g style="fill: #52514e" transform="translate(29.885825 225.452992) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-18"/>
-       <use xlink:href="#HelveticaNeue-1c" transform="translate(55.59375 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(111.1875 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(166.78125 0)"/>
+      <g style="fill: #52514e" transform="translate(26.315425 218.496797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-31"/>
+       <use xlink:href="#HelveticaNeue-35" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+       <use xlink:href="#HelveticaNeue-30" x="166.799973"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_27">
-      <path d="M 56.7352 162.474822 
-L 793.1232 162.474822 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_33">
+      <path d="M 53.1648 157.627969 
+L 834.3648 157.627969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_28"/>
-     <g id="text_15">
+     <g id="line2d_34"/>
+     <g id="text_18">
       <!-- 2000 -->
-      <g style="fill: #52514e" transform="translate(29.885825 167.472822) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-19"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(55.59375 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(111.1875 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(166.78125 0)"/>
+      <g style="fill: #52514e" transform="translate(26.315425 161.376797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-32"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+       <use xlink:href="#HelveticaNeue-30" x="166.799973"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_29">
-      <path d="M 56.7352 104.494653 
-L 793.1232 104.494653 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     <g id="line2d_35">
+      <path d="M 53.1648 100.507969 
+L 834.3648 100.507969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
      </g>
-     <g id="line2d_30"/>
-     <g id="text_16">
+     <g id="line2d_36"/>
+     <g id="text_19">
       <!-- 2500 -->
-      <g style="fill: #52514e" transform="translate(29.885825 109.492653) scale(0.105 -0.105)">
-       <use xlink:href="#HelveticaNeue-19"/>
-       <use xlink:href="#HelveticaNeue-1c" transform="translate(55.59375 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(111.1875 0)"/>
-       <use xlink:href="#HelveticaNeue-17" transform="translate(166.78125 0)"/>
+      <g style="fill: #52514e" transform="translate(26.315425 104.256797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-32"/>
+       <use xlink:href="#HelveticaNeue-35" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+       <use xlink:href="#HelveticaNeue-30" x="166.799973"/>
       </g>
      </g>
     </g>
-    <g id="text_17">
+    <g id="ytick_7">
+     <g id="line2d_37">
+      <path d="M 53.1648 43.387969 
+L 834.3648 43.387969 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #e9e8e3; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38"/>
+     <g id="text_20">
+      <!-- 3000 -->
+      <g style="fill: #52514e" transform="translate(26.315425 47.136797) scale(0.105 -0.105)">
+       <use xlink:href="#HelveticaNeue-33"/>
+       <use xlink:href="#HelveticaNeue-30" x="55.599991"/>
+       <use xlink:href="#HelveticaNeue-30" x="111.199982"/>
+       <use xlink:href="#HelveticaNeue-30" x="166.799973"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_21">
      <!-- total throughput (tok/s per GPU) -->
-     <g style="fill: #1a1b1d" transform="translate(18.542825 302.202516) rotate(-90) scale(0.11 -0.11)">
+     <g style="fill: #52514e" transform="translate(15.015737 293.599062) rotate(-90) scale(0.11 -0.11)">
       <defs>
-       <path id="HelveticaNeue-48" d="M 3341 13 
+       <path id="HelveticaNeue-61" d="M 3341 13 
 Q 3200 -70 2950 -70 
 Q 2739 -70 2614 48 
 Q 2490 166 2490 435 
@@ -1235,14 +1300,14 @@ Q 2458 1037 2458 1152
 L 2458 1709 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-53" d="M 442 4570 
+       <path id="HelveticaNeue-6c" d="M 442 4570 
 L 442 0 
 L 986 0 
 L 986 4570 
 L 442 4570 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-4f" d="M 410 4570 
+       <path id="HelveticaNeue-68" d="M 410 4570 
 L 410 0 
 L 954 0 
 L 954 1869 
@@ -1268,7 +1333,7 @@ L 954 4570
 L 410 4570 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-4e" d="M 3264 282 
+       <path id="HelveticaNeue-67" d="M 3264 282 
 L 3264 3309 
 L 2752 3309 
 L 2752 2835 
@@ -1322,7 +1387,7 @@ Q 2387 666 2198 554
 Q 2010 442 1741 442 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-2e" d="M 3917 570 
+       <path id="HelveticaNeue-47" d="M 3917 570 
 L 4077 0 
 L 4461 0 
 L 4461 2406 
@@ -1362,7 +1427,7 @@ Q 2854 -102 3251 54
 Q 3648 211 3917 570 
 z
 " transform="scale(0.015625)"/>
-       <path id="HelveticaNeue-3c" d="M 4147 1651 
+       <path id="HelveticaNeue-55" d="M 4147 1651 
 L 4147 4570 
 L 3539 4570 
 L 3539 1651 
@@ -1380,465 +1445,354 @@ Q 4147 774 4147 1651
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#HelveticaNeue-5b"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(31.5 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(88.90625 0)"/>
-      <use xlink:href="#HelveticaNeue-48" transform="translate(120.40625 0)"/>
-      <use xlink:href="#HelveticaNeue-53" transform="translate(174.109375 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(196.3125 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(224.109375 0)"/>
-      <use xlink:href="#HelveticaNeue-4f" transform="translate(255.609375 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(311.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(342.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-5c" transform="translate(400.109375 0)"/>
-      <use xlink:href="#HelveticaNeue-4e" transform="translate(455.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-4f" transform="translate(513.109375 0)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(568.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-5c" transform="translate(628 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(683.59375 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(715.09375 0)"/>
-      <use xlink:href="#HelveticaNeue-f" transform="translate(742.890625 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(768.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(800.296875 0)"/>
-      <use xlink:href="#HelveticaNeue-52" transform="translate(857.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-16" transform="translate(909.609375 0)"/>
-      <use xlink:href="#HelveticaNeue-5a" transform="translate(942.90625 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(992.90625 0)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(1020.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(1080 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(1133.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(1167 0)"/>
-      <use xlink:href="#HelveticaNeue-2e" transform="translate(1194.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(1270.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-3c" transform="translate(1335.5 0)"/>
-      <use xlink:href="#HelveticaNeue-10" transform="translate(1407.703125 0)"/>
+      <use xlink:href="#HelveticaNeue-74"/>
+      <use xlink:href="#HelveticaNeue-6f" x="31.499985"/>
+      <use xlink:href="#HelveticaNeue-74" x="88.899979"/>
+      <use xlink:href="#HelveticaNeue-61" x="120.399963"/>
+      <use xlink:href="#HelveticaNeue-6c" x="174.09996"/>
+      <use xlink:href="#HelveticaNeue-20" x="196.299957"/>
+      <use xlink:href="#HelveticaNeue-74" x="224.099945"/>
+      <use xlink:href="#HelveticaNeue-68" x="255.59993"/>
+      <use xlink:href="#HelveticaNeue-72" x="311.199921"/>
+      <use xlink:href="#HelveticaNeue-6f" x="342.749908"/>
+      <use xlink:href="#HelveticaNeue-75" x="400.149902"/>
+      <use xlink:href="#HelveticaNeue-67" x="455.749893"/>
+      <use xlink:href="#HelveticaNeue-68" x="513.149887"/>
+      <use xlink:href="#HelveticaNeue-70" x="568.749878"/>
+      <use xlink:href="#HelveticaNeue-75" x="628.049866"/>
+      <use xlink:href="#HelveticaNeue-74" x="683.649857"/>
+      <use xlink:href="#HelveticaNeue-20" x="715.149841"/>
+      <use xlink:href="#HelveticaNeue-28" x="742.949829"/>
+      <use xlink:href="#HelveticaNeue-74" x="768.849823"/>
+      <use xlink:href="#HelveticaNeue-6f" x="800.349808"/>
+      <use xlink:href="#HelveticaNeue-6b" x="857.749802"/>
+      <use xlink:href="#HelveticaNeue-2f" x="909.649796"/>
+      <use xlink:href="#HelveticaNeue-73" x="942.949783"/>
+      <use xlink:href="#HelveticaNeue-20" x="992.949768"/>
+      <use xlink:href="#HelveticaNeue-70" x="1020.749756"/>
+      <use xlink:href="#HelveticaNeue-65" x="1080.049744"/>
+      <use xlink:href="#HelveticaNeue-72" x="1133.749741"/>
+      <use xlink:href="#HelveticaNeue-20" x="1167.049728"/>
+      <use xlink:href="#HelveticaNeue-47" x="1194.849716"/>
+      <use xlink:href="#HelveticaNeue-50" x="1270.74971"/>
+      <use xlink:href="#HelveticaNeue-55" x="1335.549698"/>
+      <use xlink:href="#HelveticaNeue-29" x="1407.74968"/>
      </g>
     </g>
    </g>
-   <g id="line2d_31">
-    <path d="M 147.6821 79.550251 
-L 148.285003 87.565764 
-L 149.027057 98.983025 
-L 186.133297 170.35226 
-L 248.123973 172.89177 
-L 250.541313 184.177287 
-L 253.826683 186.630632 
-L 265.656389 192.204574 
-L 351.933526 230.343069 
-L 367.551958 240.35519 
-L 367.652888 243.838003 
-L 406.324624 260.298219 
-L 423.901445 269.993573 
-L 446.758041 273.345105 
-L 450.941993 283.324254 
-L 501.218774 314.194211 
-L 578.470533 324.445654 
-L 723.416358 352.033816 
-" clip-path="url(#pc898bb3ed9)" style="fill: none; stroke: #1a1b1d; stroke-width: 2.6; stroke-linecap: square"/>
+   <g id="line2d_39">
+    <path d="M 136.966713 65.371279 
+L 137.540042 75.933632 
+L 138.011606 83.83023 
+L 138.592008 95.078109 
+L 153.632257 114.042476 
+L 216.101147 167.890375 
+L 220.561549 181.425413 
+L 229.814212 186.916663 
+L 297.296299 224.489351 
+L 309.512332 234.352936 
+L 309.591275 237.78408 
+L 339.838563 254.000099 
+L 353.58636 263.551616 
+L 371.463759 266.853427 
+L 374.736258 276.684529 
+L 410.417153 302.439014 
+L 414.060489 307.096512 
+L 430.949485 309.6054 
+L 474.483332 317.19587 
+L 553.741831 335.451029 
+L 587.853421 344.374745 
+L 608.462091 353.144285 
+L 665.434623 355.890015 
+L 695.27876 366.233889 
+L 728.431789 368.809278 
+L 752.506036 372.759666 
+L 778.930219 376.839187 
+L 780.385264 382.544017 
+" clip-path="url(#p1582a3b38b)" style="fill: none; stroke: #1a1b1d; stroke-width: 2.6; stroke-linecap: round"/>
    </g>
    <g id="patch_3">
-    <path d="M 56.7352 394.3955 
-L 56.7352 52.3125 
+    <path d="M 53.1648 386.107969 
+L 53.1648 43.387969 
 " style="fill: none; stroke: #c8c7c1; stroke-width: 0.9; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 56.7352 394.3955 
-L 793.1232 394.3955 
+    <path d="M 53.1648 386.107969 
+L 834.3648 386.107969 
 " style="fill: none; stroke: #c8c7c1; stroke-width: 0.9; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="line2d_32">
+   <g id="line2d_40">
     <defs>
-     <path id="mce57ce64a3" d="M 0 4 
-C 1.060812 4 2.078319 3.578535 2.828427 2.828427 
-C 3.578535 2.078319 4 1.060812 4 0 
-C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427 
-C 2.078319 -3.578535 1.060812 -4 0 -4 
-C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427 
-C -3.578535 -2.078319 -4 -1.060812 -4 0 
-C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427 
-C -2.078319 3.578535 -1.060812 4 0 4 
+     <path id="md7a466de16" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
 z
 " style="stroke: #fcfcfb; stroke-width: 1.4"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="536.765139" y="344.574879" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_33">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="418.72612" y="316.391824" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_34">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="679.31329" y="361.45795" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_35">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="539.215212" y="344.783133" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_36">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="420.209075" y="315.816617" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_37">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="682.291148" y="361.6652" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_38">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="186.133297" y="170.35226" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_39">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="356.877395" y="294.485306" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_40">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="260.560394" y="243.946847" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#md7a466de16" x="441.863253" y="337.026466" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="349.538454" y="309.261523" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="553.35799" y="353.659066" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="443.779589" y="337.23163" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="350.698355" y="308.694849" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="555.687135" y="353.863242" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="167.614835" y="165.388541" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="301.16317" y="287.68" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="225.828354" y="237.891309" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="203.608164" y="207.275429" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="151.397074" y="125.235136" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="138.011606" y="83.83023" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="270.844891" y="268.762664" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="137.540042" y="75.933632" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="151.53798" y="125.592194" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="271.14132" y="268.374697" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+     <use xlink:href="#md7a466de16" x="555.008189" y="354.110399" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
     </g>
    </g>
    <g id="line2d_41">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="232.151456" y="212.869923" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+    <defs>
+     <path id="m781f438463" d="M 0 -3 
+L -3 3 
+L 3 3 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m781f438463" x="135.814222" y="85.347443" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="136.45201" y="96.077227" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="136.413308" y="100.711124" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="198.365125" y="214.082355" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="149.106993" y="132.662826" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="133.907008" y="79.64051" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="149.836438" y="131.500071" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="258.419808" y="273.613302" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m781f438463" x="509.310521" y="356.086553" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_42">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="165.398579" y="129.594186" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+    <defs>
+     <path id="m1a2249dbbc" d="M -2.8 2.8 
+L 2.8 2.8 
+L 2.8 -2.8 
+L -2.8 -2.8 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m1a2249dbbc" x="229.814212" y="186.916663" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a2249dbbc" x="220.561549" y="181.425413" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a2249dbbc" x="216.101147" y="167.890375" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a2249dbbc" x="273.652046" y="237.668072" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a2249dbbc" x="229.66041" y="192.26862" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a2249dbbc" x="217.991881" y="179.008465" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_43">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="148.285003" y="87.565764" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+    <defs>
+     <path id="m38faf0c88f" d="M -1.166667 3.5 
+L 1.166667 3.5 
+L 1.166667 1.166667 
+L 3.5 1.166667 
+L 3.5 -1.166667 
+L 1.166667 -1.166667 
+L 1.166667 -3.5 
+L -1.166667 -3.5 
+L -1.166667 -1.166667 
+L -3.5 -1.166667 
+L -3.5 1.166667 
+L -1.166667 1.166667 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m38faf0c88f" x="135.715866" y="94.998168" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m38faf0c88f" x="135.529331" y="85.345274" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_44">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="318.114896" y="275.283094" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+    <defs>
+     <path id="m3577f524eb" d="M 3 0 
+L -3 -3 
+L -3 3 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m3577f524eb" x="200.636903" y="184.473769" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m3577f524eb" x="200.591477" y="189.055671" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m3577f524eb" x="201.392263" y="201.584367" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_45">
     <defs>
-     <path id="mabcc5902ca" d="M 0 -4 
-L -4 4 
-L 4 4 
+     <path id="m73dcf444f8" d="M -3 -0 
+L 3 3 
+L 3 -3 
 z
 " style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="145.475605" y="89.105824" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m73dcf444f8" x="138.592008" y="95.078109" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m73dcf444f8" x="137.414874" y="85.044747" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_46">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="146.29103" y="99.997189" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <defs>
+     <path id="m1886d6ca30" d="M -0 3.818377 
+L 3.818377 0 
+L 0 -3.818377 
+L -3.818377 -0 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m1886d6ca30" x="297.296299" y="224.489351" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1886d6ca30" x="309.591275" y="237.78408" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1886d6ca30" x="309.512332" y="234.352936" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1886d6ca30" x="330.663073" y="260.091637" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m1886d6ca30" x="414.060489" y="307.096512" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_47">
     <defs>
-     <path id="m6c29795d04" d="M -4 4 
-L 4 4 
-L 4 -4 
-L -4 -4 
+     <path id="m7d7510e2da" d="M -0 3 
+L 3 -3 
+L -3 -3 
 z
 " style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="265.656389" y="192.204574" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m7d7510e2da" x="339.838563" y="254.000099" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d7510e2da" x="371.463759" y="266.853427" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d7510e2da" x="353.58636" y="263.551616" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d7510e2da" x="374.736258" y="276.684529" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d7510e2da" x="587.853421" y="344.374745" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d7510e2da" x="474.483332" y="317.19587" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_48">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="253.826683" y="186.630632" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <defs>
+     <path id="mb6816ce147" d="M -1.5 3 
+L 0 1.5 
+L 1.5 3 
+L 3 1.5 
+L 1.5 0 
+L 3 -1.5 
+L 1.5 -3 
+L 0 -1.5 
+L -1.5 -3 
+L -3 -1.5 
+L -1.5 0 
+L -3 1.5 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#mb6816ce147" x="145.940508" y="160.542606" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6816ce147" x="146.797486" y="171.214256" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6816ce147" x="211.876115" y="290.827798" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6816ce147" x="308.0104" y="367.115416" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_49">
     <defs>
-     <path id="m655a7782e0" d="M -1.333333 4 
-L 1.333333 4 
-L 1.333333 1.333333 
-L 4 1.333333 
-L 4 -1.333333 
-L 1.333333 -1.333333 
-L 1.333333 -4 
-L -1.333333 -4 
-L -1.333333 -1.333333 
-L -4 -1.333333 
-L -4 1.333333 
-L -1.333333 1.333333 
+     <path id="m4eb6b22513" d="M 0 -2.7 
+L -0.606188 -0.834346 
+L -2.567853 -0.834346 
+L -0.980832 0.318692 
+L -1.58702 2.184346 
+L -0 1.031308 
+L 1.58702 2.184346 
+L 0.980832 0.318692 
+L 2.567853 -0.834346 
+L 0.606188 -0.834346 
 z
-" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m655a7782e0" x="145.349855" y="98.90188" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m4eb6b22513" x="139.73687" y="148.491684" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4eb6b22513" x="215.086959" y="290.953333" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4eb6b22513" x="305.281694" y="366.926882" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_50">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m655a7782e0" x="145.111366" y="89.103623" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <defs>
+     <path id="m2846000dfd" d="M 0 -3.2 
+L -2.771281 -1.6 
+L -2.771281 1.6 
+L -0 3.2 
+L 2.771281 1.6 
+L 2.771281 -1.6 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m2846000dfd" x="136.966713" y="65.371279" style="fill: #0f7b72; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m2846000dfd" x="153.632257" y="114.042476" style="fill: #0f7b72; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_51">
     <defs>
-     <path id="m1080350280" d="M 4 0 
-L -4 -4 
-L -4 4 
+     <path id="m6504e2d535" d="M 0 -3.2 
+L -3.043381 -0.988854 
+L -1.880913 2.588854 
+L 1.880913 2.588854 
+L 3.043381 -0.988854 
 z
 " style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m1080350280" x="228.352642" y="189.724893" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m6504e2d535" x="410.417153" y="302.439014" style="fill: #5cb3aa; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m6504e2d535" x="608.462091" y="353.144285" style="fill: #5cb3aa; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m6504e2d535" x="695.27876" y="366.233889" style="fill: #5cb3aa; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_52">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="146.241548" y="104.700867" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <defs>
+     <path id="m54cb7b72e9" d="M -0 4.101219 
+L 2.460732 0 
+L 0 -4.101219 
+L -2.460732 0 
+z
+" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#m54cb7b72e9" x="430.949485" y="309.6054" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m54cb7b72e9" x="553.741831" y="335.451029" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m54cb7b72e9" x="665.434623" y="355.890015" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m54cb7b72e9" x="728.431789" y="368.809278" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#m54cb7b72e9" x="778.930219" y="376.839187" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_53">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="225.44813" y="219.779354" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_54">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="162.470667" y="137.133729" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_55">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m1080350280" x="228.294564" y="194.375793" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_56">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m1080350280" x="229.318383" y="207.093159" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_57">
     <defs>
-     <path id="m3038e22dff" d="M -4 -0 
-L 4 4 
-L 4 -4 
+     <path id="mfb8fc8c0f1" d="M -1.109782 -2.679251 
+L -2.679251 -1.109782 
+L -2.679251 1.109782 
+L -1.109782 2.679251 
+L 1.109782 2.679251 
+L 2.679251 1.109782 
+L 2.679251 -1.109782 
+L 1.109782 -2.679251 
 z
 " style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m3038e22dff" x="149.027057" y="98.983025" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1582a3b38b)">
+     <use xlink:href="#mfb8fc8c0f1" x="752.506036" y="372.759666" style="fill: #b49ad1; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb8fc8c0f1" x="780.385264" y="382.544017" style="fill: #b49ad1; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_58">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m3038e22dff" x="147.52207" y="88.79857" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_59">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="248.123973" y="172.89177" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_60">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="321.703897" y="243.720248" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_61">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="265.45975" y="197.637126" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_62">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c29795d04" x="250.541313" y="184.177287" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_63">
-    <defs>
-     <path id="m6c1b33c3de" d="M -0 5.656854 
-L 5.656854 0 
-L 0 -5.656854 
-L -5.656854 -0 
-z
-" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c1b33c3de" x="351.933526" y="230.343069" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_64">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c1b33c3de" x="367.652888" y="243.838003" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_65">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c1b33c3de" x="367.551958" y="240.35519" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_66">
-    <defs>
-     <path id="m51497f9b2e" d="M -0 4 
-L 4 -4 
-L -4 -4 
-z
-" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="406.324624" y="260.298219" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_67">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="446.758041" y="273.345105" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_68">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="423.901445" y="269.993573" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_69">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="147.6821" y="79.550251" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_70">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="165.578731" y="129.956621" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_71">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="318.493886" y="274.889284" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_72">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mce57ce64a3" x="681.423102" y="361.916079" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
-    </g>
-   </g>
-   <g id="line2d_73">
-    <defs>
-     <path id="m278e68defa" d="M -2 4 
-L 0 2 
-L 2 4 
-L 4 2 
-L 2 0 
-L 4 -2 
-L 2 -4 
-L 0 -2 
-L -2 -4 
-L -4 -2 
-L -2 0 
-L -4 2 
-z
-" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m278e68defa" x="158.422255" y="165.433351" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_74">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m278e68defa" x="159.517919" y="176.265705" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_75">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m278e68defa" x="242.722189" y="297.680506" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_76">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m278e68defa" x="365.631709" y="375.116939" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_77">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="143.037196" y="83.312951" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_78">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="163.403276" y="135.953464" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_79">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="302.22919" y="280.206777" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_80">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#mabcc5902ca" x="622.99776" y="363.921992" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_81">
-    <defs>
-     <path id="md659ae9f1e" d="M 0 -4 
-L -0.898056 -1.236068 
-L -3.804226 -1.236068 
-L -1.453085 0.472136 
-L -2.351141 3.236068 
-L -0 1.527864 
-L 2.351141 3.236068 
-L 1.453085 0.472136 
-L 3.804226 -1.236068 
-L 0.898056 -1.236068 
-z
-" style="stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#md659ae9f1e" x="150.490786" y="153.200954" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_82">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#md659ae9f1e" x="246.827314" y="297.807931" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_83">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#md659ae9f1e" x="362.143006" y="374.925566" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_84">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="450.941993" y="283.324254" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_85">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="723.416358" y="352.033816" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_86">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m51497f9b2e" x="578.470533" y="324.445654" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_87">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c1b33c3de" x="394.593584" y="266.48149" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_88">
-    <g clip-path="url(#pc898bb3ed9)">
-     <use xlink:href="#m6c1b33c3de" x="501.218774" y="314.194211" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- PD disaggregation on GB300 · 8K in / 1K out · 57 measured points, prefill is chunked PP8 throughout -->
-    <g style="fill: #6d716c" transform="translate(56.7352 39.60051) scale(0.115 -0.115)">
+   <g id="text_22">
+    <!-- PD disaggregation on GB300 · 8K in / 1K out · 69 measured points across 14 prefill × decode arms -->
+    <g style="fill: #52514e" transform="translate(53.1648 28.98855) scale(0.115 -0.115)">
      <defs>
-      <path id="HelveticaNeue-2b" d="M 1107 512 
+      <path id="HelveticaNeue-44" d="M 1107 512 
 L 1107 4058 
 L 2131 4058 
 Q 2554 4058 2842 3939 
@@ -1865,7 +1819,7 @@ Q 3123 4570 2067 4570
 L 499 4570 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-50" d="M 986 3904 
+      <path id="HelveticaNeue-69" d="M 986 3904 
 L 986 4570 
 L 442 4570 
 L 442 3904 
@@ -1878,7 +1832,7 @@ L 986 3309
 L 442 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-55" d="M 410 3309 
+      <path id="HelveticaNeue-6e" d="M 410 3309 
 L 410 0 
 L 954 0 
 L 954 1869 
@@ -1901,7 +1855,7 @@ L 922 3309
 L 410 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-29" d="M 1107 2605 
+      <path id="HelveticaNeue-42" d="M 1107 2605 
 L 1107 4058 
 L 2323 4058 
 Q 2522 4058 2698 4035 
@@ -1944,7 +1898,7 @@ Q 3034 512 2630 512
 L 1107 512 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-c7" d="M 480 1990 
+      <path id="HelveticaNeue-b7" d="M 480 1990 
 Q 480 1824 605 1702 
 Q 730 1581 896 1581 
 Q 1056 1581 1177 1709 
@@ -1955,7 +1909,7 @@ Q 723 2400 601 2278
 Q 480 2157 480 1990 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-32" d="M 499 4570 
+      <path id="HelveticaNeue-4b" d="M 499 4570 
 L 499 0 
 L 1107 0 
 L 1107 1600 
@@ -1970,7 +1924,7 @@ L 1107 4570
 L 499 4570 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-54" d="M 410 3309 
+      <path id="HelveticaNeue-6d" d="M 410 3309 
 L 410 0 
 L 954 0 
 L 954 2061 
@@ -2008,33 +1962,7 @@ L 922 3309
 L 410 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-13" d="M 531 710 
-L 531 0 
-L 909 0 
-Q 915 -77 899 -166 
-Q 883 -256 838 -342 
-Q 794 -429 720 -502 
-Q 646 -576 538 -614 
-L 538 -934 
-Q 909 -826 1075 -563 
-Q 1242 -301 1242 64 
-L 1242 710 
-L 531 710 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-c4" d="M 2336 0 
-L 2880 0 
-L 2880 3309 
-L 2336 3309 
-L 2336 0 
-z
-M 2336 3904 
-L 2880 3904 
-L 2880 4570 
-L 2336 4570 
-L 2336 3904 
-z
-M 634 2829 
+      <path id="HelveticaNeue-66" d="M 634 2829 
 L 634 0 
 L 1178 0 
 L 1178 2829 
@@ -2057,639 +1985,176 @@ L 77 2829
 L 634 2829 
 z
 " transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-d7" d="M 454 461 
+L 762 154 
+L 1926 1318 
+L 3085 154 
+L 3392 461 
+L 2234 1626 
+L 3386 2778 
+L 3078 3085 
+L 1926 1933 
+L 768 3085 
+L 461 2778 
+L 1619 1626 
+L 454 461 
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#HelveticaNeue-37"/>
-     <use xlink:href="#HelveticaNeue-2b" transform="translate(64.796875 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(135.203125 0)"/>
-     <use xlink:href="#HelveticaNeue-4b" transform="translate(163 0)"/>
-     <use xlink:href="#HelveticaNeue-50" transform="translate(222.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(244.5 0)"/>
-     <use xlink:href="#HelveticaNeue-48" transform="translate(294.5 0)"/>
-     <use xlink:href="#HelveticaNeue-4e" transform="translate(348.203125 0)"/>
-     <use xlink:href="#HelveticaNeue-4e" transform="translate(405.609375 0)"/>
-     <use xlink:href="#HelveticaNeue-59" transform="translate(463.015625 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(494.515625 0)"/>
-     <use xlink:href="#HelveticaNeue-4e" transform="translate(548.21875 0)"/>
-     <use xlink:href="#HelveticaNeue-48" transform="translate(605.625 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(659.328125 0)"/>
-     <use xlink:href="#HelveticaNeue-50" transform="translate(690.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(713.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(770.4375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(826.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(853.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(911.234375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(966.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-2e" transform="translate(994.625 0)"/>
-     <use xlink:href="#HelveticaNeue-29" transform="translate(1070.53125 0)"/>
-     <use xlink:href="#HelveticaNeue-1a" transform="translate(1139.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-17" transform="translate(1194.625 0)"/>
-     <use xlink:href="#HelveticaNeue-17" transform="translate(1250.21875 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1305.8125 0)"/>
-     <use xlink:href="#HelveticaNeue-c7" transform="translate(1333.609375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1361.40625 0)"/>
-     <use xlink:href="#HelveticaNeue-1f" transform="translate(1389.203125 0)"/>
-     <use xlink:href="#HelveticaNeue-32" transform="translate(1444.796875 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1511.5 0)"/>
-     <use xlink:href="#HelveticaNeue-50" transform="translate(1539.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(1561.5 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1617.09375 0)"/>
-     <use xlink:href="#HelveticaNeue-16" transform="translate(1644.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1678.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-18" transform="translate(1705.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-32" transform="translate(1761.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(1828.28125 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(1856.078125 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(1913.484375 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(1969.078125 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(2000.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-c7" transform="translate(2028.375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(2056.171875 0)"/>
-     <use xlink:href="#HelveticaNeue-1c" transform="translate(2083.96875 0)"/>
-     <use xlink:href="#HelveticaNeue-1e" transform="translate(2139.5625 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(2195.15625 0)"/>
-     <use xlink:href="#HelveticaNeue-54" transform="translate(2222.953125 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(2308.25 0)"/>
-     <use xlink:href="#HelveticaNeue-48" transform="translate(2361.953125 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(2415.65625 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(2465.65625 0)"/>
-     <use xlink:href="#HelveticaNeue-59" transform="translate(2521.25 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(2552.75 0)"/>
-     <use xlink:href="#HelveticaNeue-4b" transform="translate(2606.453125 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(2665.75 0)"/>
-     <use xlink:href="#HelveticaNeue-57" transform="translate(2693.546875 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(2752.84375 0)"/>
-     <use xlink:href="#HelveticaNeue-50" transform="translate(2810.25 0)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(2832.453125 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(2888.046875 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(2919.546875 0)"/>
-     <use xlink:href="#HelveticaNeue-13" transform="translate(2969.546875 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(2997.34375 0)"/>
-     <use xlink:href="#HelveticaNeue-57" transform="translate(3025.140625 0)"/>
-     <use xlink:href="#HelveticaNeue-59" transform="translate(3084.4375 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(3115.9375 0)"/>
-     <use xlink:href="#HelveticaNeue-c4" transform="translate(3169.640625 0)"/>
-     <use xlink:href="#HelveticaNeue-53" transform="translate(3221.4375 0)"/>
-     <use xlink:href="#HelveticaNeue-53" transform="translate(3243.640625 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(3265.84375 0)"/>
-     <use xlink:href="#HelveticaNeue-50" transform="translate(3293.640625 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(3315.84375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(3365.84375 0)"/>
-     <use xlink:href="#HelveticaNeue-4a" transform="translate(3393.640625 0)"/>
-     <use xlink:href="#HelveticaNeue-4f" transform="translate(3447.34375 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(3502.9375 0)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(3558.53125 0)"/>
-     <use xlink:href="#HelveticaNeue-52" transform="translate(3614.125 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(3666.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-4b" transform="translate(3719.734375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(3779.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-37" transform="translate(3806.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-37" transform="translate(3871.625 0)"/>
-     <use xlink:href="#HelveticaNeue-1f" transform="translate(3936.421875 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(3992.015625 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(4019.8125 0)"/>
-     <use xlink:href="#HelveticaNeue-4f" transform="translate(4051.3125 0)"/>
-     <use xlink:href="#HelveticaNeue-59" transform="translate(4106.90625 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(4138.40625 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(4195.8125 0)"/>
-     <use xlink:href="#HelveticaNeue-4e" transform="translate(4251.40625 0)"/>
-     <use xlink:href="#HelveticaNeue-4f" transform="translate(4308.8125 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(4364.40625 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(4421.8125 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(4477.40625 0)"/>
+     <use xlink:href="#HelveticaNeue-50"/>
+     <use xlink:href="#HelveticaNeue-44" x="64.799988"/>
+     <use xlink:href="#HelveticaNeue-20" x="135.199982"/>
+     <use xlink:href="#HelveticaNeue-64" x="162.999969"/>
+     <use xlink:href="#HelveticaNeue-69" x="222.299957"/>
+     <use xlink:href="#HelveticaNeue-73" x="244.499954"/>
+     <use xlink:href="#HelveticaNeue-61" x="294.499939"/>
+     <use xlink:href="#HelveticaNeue-67" x="348.199936"/>
+     <use xlink:href="#HelveticaNeue-67" x="405.59993"/>
+     <use xlink:href="#HelveticaNeue-72" x="462.999924"/>
+     <use xlink:href="#HelveticaNeue-65" x="494.549911"/>
+     <use xlink:href="#HelveticaNeue-67" x="548.249908"/>
+     <use xlink:href="#HelveticaNeue-61" x="605.649902"/>
+     <use xlink:href="#HelveticaNeue-74" x="659.349899"/>
+     <use xlink:href="#HelveticaNeue-69" x="690.849884"/>
+     <use xlink:href="#HelveticaNeue-6f" x="713.049881"/>
+     <use xlink:href="#HelveticaNeue-6e" x="770.449875"/>
+     <use xlink:href="#HelveticaNeue-20" x="826.049866"/>
+     <use xlink:href="#HelveticaNeue-6f" x="853.849854"/>
+     <use xlink:href="#HelveticaNeue-6e" x="911.249847"/>
+     <use xlink:href="#HelveticaNeue-20" x="966.849838"/>
+     <use xlink:href="#HelveticaNeue-47" x="994.649826"/>
+     <use xlink:href="#HelveticaNeue-42" x="1070.54982"/>
+     <use xlink:href="#HelveticaNeue-33" x="1139.049805"/>
+     <use xlink:href="#HelveticaNeue-30" x="1194.649796"/>
+     <use xlink:href="#HelveticaNeue-30" x="1250.249786"/>
+     <use xlink:href="#HelveticaNeue-20" x="1305.849777"/>
+     <use xlink:href="#HelveticaNeue-b7" x="1333.649765"/>
+     <use xlink:href="#HelveticaNeue-20" x="1361.449753"/>
+     <use xlink:href="#HelveticaNeue-38" x="1389.249741"/>
+     <use xlink:href="#HelveticaNeue-4b" x="1444.849731"/>
+     <use xlink:href="#HelveticaNeue-20" x="1511.549728"/>
+     <use xlink:href="#HelveticaNeue-69" x="1539.349716"/>
+     <use xlink:href="#HelveticaNeue-6e" x="1561.549713"/>
+     <use xlink:href="#HelveticaNeue-20" x="1617.149704"/>
+     <use xlink:href="#HelveticaNeue-2f" x="1644.949692"/>
+     <use xlink:href="#HelveticaNeue-20" x="1678.24968"/>
+     <use xlink:href="#HelveticaNeue-31" x="1706.049667"/>
+     <use xlink:href="#HelveticaNeue-4b" x="1761.649658"/>
+     <use xlink:href="#HelveticaNeue-20" x="1828.349655"/>
+     <use xlink:href="#HelveticaNeue-6f" x="1856.149643"/>
+     <use xlink:href="#HelveticaNeue-75" x="1913.549637"/>
+     <use xlink:href="#HelveticaNeue-74" x="1969.149628"/>
+     <use xlink:href="#HelveticaNeue-20" x="2000.649612"/>
+     <use xlink:href="#HelveticaNeue-b7" x="2028.4496"/>
+     <use xlink:href="#HelveticaNeue-20" x="2056.249588"/>
+     <use xlink:href="#HelveticaNeue-36" x="2084.049576"/>
+     <use xlink:href="#HelveticaNeue-39" x="2139.649567"/>
+     <use xlink:href="#HelveticaNeue-20" x="2195.249557"/>
+     <use xlink:href="#HelveticaNeue-6d" x="2223.049545"/>
+     <use xlink:href="#HelveticaNeue-65" x="2308.349533"/>
+     <use xlink:href="#HelveticaNeue-61" x="2362.04953"/>
+     <use xlink:href="#HelveticaNeue-73" x="2415.749527"/>
+     <use xlink:href="#HelveticaNeue-75" x="2465.749512"/>
+     <use xlink:href="#HelveticaNeue-72" x="2521.349503"/>
+     <use xlink:href="#HelveticaNeue-65" x="2552.89949"/>
+     <use xlink:href="#HelveticaNeue-64" x="2606.599487"/>
+     <use xlink:href="#HelveticaNeue-20" x="2665.899475"/>
+     <use xlink:href="#HelveticaNeue-70" x="2693.699463"/>
+     <use xlink:href="#HelveticaNeue-6f" x="2752.999451"/>
+     <use xlink:href="#HelveticaNeue-69" x="2810.399445"/>
+     <use xlink:href="#HelveticaNeue-6e" x="2832.599442"/>
+     <use xlink:href="#HelveticaNeue-74" x="2888.199432"/>
+     <use xlink:href="#HelveticaNeue-73" x="2919.699417"/>
+     <use xlink:href="#HelveticaNeue-20" x="2969.699402"/>
+     <use xlink:href="#HelveticaNeue-61" x="2997.49939"/>
+     <use xlink:href="#HelveticaNeue-63" x="3051.199387"/>
+     <use xlink:href="#HelveticaNeue-72" x="3104.899384"/>
+     <use xlink:href="#HelveticaNeue-6f" x="3136.449371"/>
+     <use xlink:href="#HelveticaNeue-73" x="3193.849365"/>
+     <use xlink:href="#HelveticaNeue-73" x="3243.84935"/>
+     <use xlink:href="#HelveticaNeue-20" x="3293.849335"/>
+     <use xlink:href="#HelveticaNeue-31" x="3321.649323"/>
+     <use xlink:href="#HelveticaNeue-34" x="3377.249313"/>
+     <use xlink:href="#HelveticaNeue-20" x="3432.849304"/>
+     <use xlink:href="#HelveticaNeue-70" x="3460.649292"/>
+     <use xlink:href="#HelveticaNeue-72" x="3519.94928"/>
+     <use xlink:href="#HelveticaNeue-65" x="3551.499268"/>
+     <use xlink:href="#HelveticaNeue-66" x="3605.199265"/>
+     <use xlink:href="#HelveticaNeue-69" x="3634.799255"/>
+     <use xlink:href="#HelveticaNeue-6c" x="3656.999252"/>
+     <use xlink:href="#HelveticaNeue-6c" x="3679.199249"/>
+     <use xlink:href="#HelveticaNeue-20" x="3701.399246"/>
+     <use xlink:href="#HelveticaNeue-d7" x="3729.199234"/>
+     <use xlink:href="#HelveticaNeue-20" x="3789.199219"/>
+     <use xlink:href="#HelveticaNeue-64" x="3816.999207"/>
+     <use xlink:href="#HelveticaNeue-65" x="3876.299194"/>
+     <use xlink:href="#HelveticaNeue-63" x="3929.999191"/>
+     <use xlink:href="#HelveticaNeue-6f" x="3983.699188"/>
+     <use xlink:href="#HelveticaNeue-64" x="4041.099182"/>
+     <use xlink:href="#HelveticaNeue-65" x="4100.39917"/>
+     <use xlink:href="#HelveticaNeue-20" x="4154.099167"/>
+     <use xlink:href="#HelveticaNeue-61" x="4181.899155"/>
+     <use xlink:href="#HelveticaNeue-72" x="4235.599152"/>
+     <use xlink:href="#HelveticaNeue-6d" x="4268.899139"/>
+     <use xlink:href="#HelveticaNeue-73" x="4354.199127"/>
     </g>
    </g>
-   <g id="text_19">
-    <!-- The K3 serving frontier: chunked PP8 prefill × decode topology -->
-    <g style="fill: #1a1b1d" transform="translate(56.7352 22.3125) scale(0.155 -0.155)">
+   <g id="text_23">
+    <!-- 2,808 tok/s/GPU @ 18.7 tok/s/user -->
+    <g style="fill: #1a1b1d" transform="translate(175.641071 93.591669) scale(0.095 -0.095)">
      <defs>
-      <path id="HelveticaNeue-Bold-3b" d="M 1453 3725 
-L 1453 0 
-L 2458 0 
-L 2458 3725 
-L 3827 3725 
-L 3827 4570 
-L 83 4570 
-L 83 3725 
-L 1453 3725 
+      <path id="HelveticaNeue-Bold-32" d="M 237 2758 
+L 1107 2758 
+Q 1107 2938 1142 3120 
+Q 1178 3302 1261 3452 
+Q 1344 3603 1481 3696 
+Q 1619 3789 1818 3789 
+Q 2112 3789 2301 3606 
+Q 2490 3424 2490 3098 
+Q 2490 2893 2397 2733 
+Q 2304 2573 2166 2445 
+Q 2029 2317 1862 2211 
+Q 1696 2106 1549 2003 
+Q 1261 1805 1001 1613 
+Q 742 1421 550 1193 
+Q 358 966 246 678 
+Q 134 390 134 0 
+L 3424 0 
+L 3424 781 
+L 1306 781 
+Q 1472 1011 1689 1184 
+Q 1907 1357 2137 1507 
+Q 2368 1658 2595 1811 
+Q 2822 1965 3001 2153 
+Q 3181 2342 3289 2585 
+Q 3398 2829 3398 3168 
+Q 3398 3494 3273 3756 
+Q 3149 4019 2937 4198 
+Q 2726 4378 2448 4474 
+Q 2170 4570 1862 4570 
+Q 1459 4570 1148 4432 
+Q 838 4294 633 4048 
+Q 429 3802 326 3472 
+Q 224 3142 237 2758 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4f" d="M 346 4570 
-L 346 0 
-L 1254 0 
-L 1254 1734 
-Q 1254 2240 1420 2461 
-Q 1587 2682 1958 2682 
-Q 2285 2682 2413 2480 
-Q 2541 2278 2541 1869 
-L 2541 0 
-L 3450 0 
-L 3450 2035 
-Q 3450 2342 3395 2595 
-Q 3341 2848 3206 3024 
-Q 3072 3200 2838 3299 
-Q 2605 3398 2240 3398 
-Q 1984 3398 1715 3267 
-Q 1446 3136 1274 2848 
-L 1254 2848 
-L 1254 4570 
-L 346 4570 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4c" d="M 2573 2010 
-L 1094 2010 
-Q 1101 2106 1136 2227 
-Q 1171 2349 1257 2457 
-Q 1344 2566 1488 2640 
-Q 1632 2714 1850 2714 
-Q 2182 2714 2345 2534 
-Q 2509 2355 2573 2010 
-z
-M 1094 1434 
-L 3482 1434 
-Q 3507 1818 3417 2170 
-Q 3328 2522 3126 2797 
-Q 2925 3072 2611 3235 
-Q 2298 3398 1875 3398 
-Q 1498 3398 1187 3264 
-Q 877 3130 653 2896 
-Q 429 2662 307 2342 
-Q 186 2022 186 1651 
-Q 186 1267 304 947 
-Q 422 627 640 396 
-Q 858 166 1171 41 
-Q 1485 -83 1875 -83 
-Q 2438 -83 2835 173 
-Q 3232 429 3424 1024 
-L 2624 1024 
-Q 2579 870 2380 732 
-Q 2182 595 1907 595 
-Q 1523 595 1318 793 
-Q 1114 992 1094 1434 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-3" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-32" d="M 442 4570 
-L 442 0 
-L 1446 0 
-L 1446 1472 
-L 2022 2054 
-L 3398 0 
-L 4659 0 
-L 2701 2765 
-L 4486 4570 
-L 3232 4570 
-L 1446 2675 
-L 1446 4570 
-L 442 4570 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-1a" d="M 1459 2669 
-L 1459 2029 
-Q 1626 2029 1808 2019 
-Q 1990 2010 2144 1949 
-Q 2298 1888 2397 1753 
-Q 2496 1619 2496 1363 
-Q 2496 1037 2285 848 
-Q 2074 659 1766 659 
-Q 1568 659 1424 729 
-Q 1280 800 1184 918 
-Q 1088 1037 1037 1200 
-Q 986 1363 979 1542 
-L 115 1542 
-Q 109 1152 227 851 
-Q 346 550 563 342 
-Q 781 134 1091 25 
-Q 1402 -83 1779 -83 
-Q 2106 -83 2406 13 
-Q 2707 109 2937 294 
-Q 3168 480 3305 755 
-Q 3443 1030 3443 1382 
-Q 3443 1766 3232 2041 
-Q 3021 2317 2650 2400 
-L 2650 2413 
-Q 2963 2502 3120 2752 
-Q 3277 3002 3277 3328 
-Q 3277 3629 3142 3859 
-Q 3008 4090 2793 4250 
-Q 2579 4410 2310 4490 
-Q 2042 4570 1773 4570 
-Q 1427 4570 1145 4458 
-Q 864 4346 662 4141 
-Q 461 3936 349 3651 
-Q 237 3366 224 3021 
-L 1088 3021 
-Q 1082 3366 1258 3593 
-Q 1434 3821 1779 3821 
-Q 2029 3821 2221 3667 
-Q 2413 3514 2413 3226 
-Q 2413 3034 2320 2918 
-Q 2227 2803 2083 2742 
-Q 1939 2682 1772 2669 
-Q 1606 2656 1459 2669 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-5a" d="M 1050 1075 
-L 186 1075 
-Q 198 742 336 521 
-Q 474 301 688 166 
-Q 902 32 1177 -25 
-Q 1453 -83 1741 -83 
-Q 2022 -83 2294 -28 
-Q 2566 26 2777 160 
-Q 2989 294 3120 515 
-Q 3251 736 3251 1062 
-Q 3251 1293 3161 1449 
-Q 3072 1606 2925 1712 
-Q 2778 1818 2589 1882 
-Q 2400 1946 2202 1990 
-Q 2010 2035 1824 2073 
-Q 1638 2112 1494 2160 
-Q 1350 2208 1260 2285 
-Q 1171 2362 1171 2483 
-Q 1171 2586 1222 2646 
-Q 1274 2707 1347 2739 
-Q 1421 2771 1510 2780 
-Q 1600 2790 1677 2790 
-Q 1920 2790 2099 2697 
-Q 2278 2605 2298 2342 
-L 3162 2342 
-Q 3136 2650 3005 2851 
-Q 2874 3053 2675 3174 
-Q 2477 3296 2224 3347 
-Q 1971 3398 1702 3398 
-Q 1434 3398 1178 3350 
-Q 922 3302 717 3184 
-Q 512 3066 387 2861 
-Q 262 2656 262 2336 
-Q 262 2118 352 1968 
-Q 442 1818 589 1718 
-Q 736 1619 925 1558 
-Q 1114 1498 1312 1453 
-Q 1798 1350 2070 1248 
-Q 2342 1146 2342 941 
-Q 2342 819 2284 739 
-Q 2227 659 2140 611 
-Q 2054 563 1948 540 
-Q 1843 518 1747 518 
-Q 1613 518 1488 550 
-Q 1363 582 1267 649 
-Q 1171 717 1110 822 
-Q 1050 928 1050 1075 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-59" d="M 346 3309 
-L 346 0 
-L 1254 0 
-L 1254 1491 
-Q 1254 1715 1299 1907 
-Q 1344 2099 1449 2243 
-Q 1555 2387 1728 2470 
-Q 1901 2554 2150 2554 
-Q 2234 2554 2323 2544 
-Q 2413 2534 2477 2522 
-L 2477 3366 
-Q 2368 3398 2278 3398 
-Q 2106 3398 1946 3347 
-Q 1786 3296 1645 3203 
-Q 1504 3110 1395 2979 
-Q 1286 2848 1222 2694 
-L 1210 2694 
-L 1210 3309 
-L 346 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-5d" d="M 2176 0 
-L 3296 3309 
-L 2394 3309 
-L 1696 1050 
-L 1683 1050 
-L 986 3309 
-L 32 3309 
-L 1165 0 
-L 2176 0 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-50" d="M 1280 3821 
-L 1280 4570 
-L 371 4570 
-L 371 3821 
-L 1280 3821 
-z
-M 371 3309 
-L 371 0 
-L 1280 0 
-L 1280 3309 
-L 371 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-55" d="M 346 3309 
-L 346 0 
-L 1254 0 
-L 1254 1734 
-Q 1254 2240 1420 2461 
-Q 1587 2682 1958 2682 
-Q 2285 2682 2413 2480 
-Q 2541 2278 2541 1869 
-L 2541 0 
-L 3450 0 
-L 3450 2035 
-Q 3450 2342 3395 2595 
-Q 3341 2848 3206 3024 
-Q 3072 3200 2838 3299 
-Q 2605 3398 2240 3398 
-Q 1952 3398 1677 3267 
-Q 1402 3136 1229 2848 
-L 1210 2848 
-L 1210 3309 
-L 346 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4e" d="M 1888 781 
-Q 1677 781 1536 870 
-Q 1395 960 1308 1101 
-Q 1222 1242 1187 1418 
-Q 1152 1594 1152 1773 
-Q 1152 1958 1193 2128 
-Q 1235 2298 1328 2429 
-Q 1421 2560 1558 2637 
-Q 1696 2714 1888 2714 
-Q 2112 2714 2259 2630 
-Q 2406 2547 2496 2406 
-Q 2586 2266 2624 2083 
-Q 2662 1901 2662 1696 
-Q 2662 1517 2614 1353 
-Q 2566 1190 2470 1062 
-Q 2374 934 2227 857 
-Q 2080 781 1888 781 
-z
-M 3526 211 
-L 3526 3309 
-L 2662 3309 
-L 2662 2867 
-L 2650 2867 
-Q 2483 3155 2236 3276 
-Q 1990 3398 1664 3398 
-Q 1318 3398 1052 3264 
-Q 787 3130 608 2902 
-Q 429 2675 336 2377 
-Q 243 2080 243 1760 
-Q 243 1421 323 1117 
-Q 403 813 576 585 
-Q 749 358 1017 227 
-Q 1286 96 1658 96 
-Q 1958 96 2230 221 
-Q 2502 346 2650 608 
-L 2662 608 
-L 2662 173 
-Q 2669 -179 2493 -409 
-Q 2317 -640 1933 -640 
-Q 1690 -640 1504 -541 
-Q 1318 -442 1254 -186 
-L 352 -186 
-Q 371 -467 508 -668 
-Q 646 -870 854 -998 
-Q 1062 -1126 1315 -1187 
-Q 1568 -1248 1811 -1248 
-Q 2381 -1248 2720 -1094 
-Q 3059 -941 3238 -720 
-Q 3418 -499 3472 -243 
-Q 3526 13 3526 211 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4d" d="M 544 2701 
-L 544 0 
-L 1453 0 
-L 1453 2701 
-L 2080 2701 
-L 2080 3309 
-L 1453 3309 
-L 1453 3507 
-Q 1453 3712 1533 3798 
-Q 1613 3885 1798 3885 
-Q 1971 3885 2131 3866 
-L 2131 4544 
-Q 2016 4550 1894 4560 
-Q 1773 4570 1651 4570 
-Q 1094 4570 819 4288 
-Q 544 4006 544 3565 
-L 544 3309 
-L 0 3309 
-L 0 2701 
-L 544 2701 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-56" d="M 1152 1651 
-Q 1152 1850 1190 2042 
-Q 1229 2234 1321 2381 
-Q 1414 2528 1568 2621 
-Q 1722 2714 1952 2714 
-Q 2182 2714 2339 2621 
-Q 2496 2528 2589 2381 
-Q 2682 2234 2720 2042 
-Q 2758 1850 2758 1651 
-Q 2758 1453 2720 1264 
-Q 2682 1075 2589 924 
-Q 2496 774 2339 684 
-Q 2182 595 1952 595 
-Q 1722 595 1568 684 
-Q 1414 774 1321 924 
-Q 1229 1075 1190 1264 
-Q 1152 1453 1152 1651 
-z
-M 243 1651 
-Q 243 1254 364 934 
-Q 486 614 710 387 
-Q 934 160 1248 38 
-Q 1562 -83 1952 -83 
-Q 2342 -83 2659 38 
-Q 2976 160 3200 387 
-Q 3424 614 3545 934 
-Q 3667 1254 3667 1651 
-Q 3667 2048 3545 2371 
-Q 3424 2694 3200 2921 
-Q 2976 3149 2659 3273 
-Q 2342 3398 1952 3398 
-Q 1562 3398 1248 3273 
-Q 934 3149 710 2921 
-Q 486 2694 364 2371 
-Q 243 2048 243 1651 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-5b" d="M 1498 3309 
-L 1498 4301 
-L 589 4301 
-L 589 3309 
-L 38 3309 
-L 38 2701 
-L 589 2701 
-L 589 749 
-Q 589 499 672 345 
-Q 755 192 899 109 
-Q 1043 26 1232 -3 
-Q 1421 -32 1632 -32 
-Q 1766 -32 1907 -25 
-Q 2048 -19 2163 0 
-L 2163 704 
-Q 2099 691 2028 684 
-Q 1958 678 1882 678 
-Q 1651 678 1574 755 
-Q 1498 832 1498 1062 
-L 1498 2701 
-L 2163 2701 
-L 2163 3309 
-L 1498 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-21" d="M 1395 2266 
-L 1395 3251 
-L 390 3251 
-L 390 2266 
-L 1395 2266 
-z
-M 390 986 
+      <path id="HelveticaNeue-Bold-2c" d="M 390 986 
 L 390 0 
-L 1395 0 
+L 851 0 
+Q 858 -102 826 -201 
+Q 794 -301 730 -381 
+Q 666 -461 579 -518 
+Q 493 -576 397 -595 
+L 397 -1056 
+Q 602 -1024 784 -937 
+Q 966 -851 1100 -716 
+Q 1235 -582 1315 -400 
+Q 1395 -218 1395 0 
 L 1395 986 
 L 390 986 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4a" d="M 2598 2144 
-L 3488 2144 
-Q 3469 2464 3334 2697 
-Q 3200 2931 2985 3088 
-Q 2771 3245 2499 3321 
-Q 2227 3398 1933 3398 
-Q 1530 3398 1216 3264 
-Q 902 3130 684 2890 
-Q 467 2650 355 2320 
-Q 243 1990 243 1606 
-Q 243 1235 364 924 
-Q 486 614 704 390 
-Q 922 166 1232 41 
-Q 1542 -83 1914 -83 
-Q 2573 -83 2995 262 
-Q 3418 608 3507 1267 
-L 2630 1267 
-Q 2586 960 2410 777 
-Q 2234 595 1907 595 
-Q 1696 595 1549 691 
-Q 1402 787 1315 937 
-Q 1229 1088 1190 1273 
-Q 1152 1459 1152 1638 
-Q 1152 1824 1190 2013 
-Q 1229 2202 1321 2358 
-Q 1414 2515 1561 2614 
-Q 1709 2714 1926 2714 
-Q 2509 2714 2598 2144 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-5c" d="M 3450 0 
-L 3450 3309 
-L 2541 3309 
-L 2541 1574 
-Q 2541 1069 2374 848 
-Q 2208 627 1837 627 
-Q 1510 627 1382 828 
-Q 1254 1030 1254 1440 
-L 1254 3309 
-L 346 3309 
-L 346 1274 
-Q 346 966 400 713 
-Q 454 461 588 285 
-Q 723 109 956 13 
-Q 1190 -83 1555 -83 
-Q 1843 -83 2118 45 
-Q 2394 173 2566 461 
-L 2586 461 
-L 2586 0 
-L 3450 0 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-52" d="M 429 4570 
-L 429 0 
-L 1338 0 
-L 1338 1139 
-L 1690 1478 
-L 2598 0 
-L 3699 0 
-L 2310 2093 
-L 3558 3309 
-L 2483 3309 
-L 1338 2118 
-L 1338 4570 
-L 429 4570 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-4b" d="M 2694 1664 
-Q 2694 1459 2656 1267 
-Q 2618 1075 2528 924 
-Q 2438 774 2288 684 
-Q 2138 595 1914 595 
-Q 1702 595 1552 688 
-Q 1402 781 1302 931 
-Q 1203 1082 1158 1274 
-Q 1114 1466 1114 1658 
-Q 1114 1862 1155 2051 
-Q 1197 2240 1289 2387 
-Q 1382 2534 1536 2624 
-Q 1690 2714 1914 2714 
-Q 2138 2714 2285 2624 
-Q 2432 2534 2525 2390 
-Q 2618 2246 2656 2057 
-Q 2694 1869 2694 1664 
-z
-M 2707 422 
-L 2707 0 
-L 3571 0 
-L 3571 4570 
-L 2662 4570 
-L 2662 2906 
-L 2650 2906 
-Q 2496 3149 2230 3273 
-Q 1965 3398 1670 3398 
-Q 1306 3398 1030 3254 
-Q 755 3110 572 2873 
-Q 390 2637 297 2326 
-Q 205 2016 205 1683 
-Q 205 1338 297 1018 
-Q 390 698 572 451 
-Q 755 205 1036 61 
-Q 1318 -83 1690 -83 
-Q 2016 -83 2275 35 
-Q 2534 154 2694 422 
-L 2707 422 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-37" d="M 1446 2419 
-L 1446 3789 
-L 2227 3789 
-Q 2400 3789 2560 3763 
-Q 2720 3738 2841 3664 
-Q 2963 3590 3036 3456 
-Q 3110 3322 3110 3104 
-Q 3110 2886 3036 2752 
-Q 2963 2618 2841 2544 
-Q 2720 2470 2560 2444 
-Q 2400 2419 2227 2419 
-L 1446 2419 
-z
-M 442 4570 
-L 442 0 
-L 1446 0 
-L 1446 1638 
-L 2502 1638 
-Q 2931 1638 3232 1763 
-Q 3533 1888 3721 2093 
-Q 3910 2298 3996 2563 
-Q 4083 2829 4083 3104 
-Q 4083 3386 3996 3648 
-Q 3910 3910 3721 4115 
-Q 3533 4320 3232 4445 
-Q 2931 4570 2502 4570 
-L 442 4570 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-1f" d="M 1101 3264 
+      <path id="HelveticaNeue-Bold-38" d="M 1101 3264 
 Q 1101 3418 1155 3533 
 Q 1210 3648 1306 3725 
 Q 1402 3802 1526 3843 
@@ -2748,300 +2213,182 @@ Q 1126 902 1062 1043
 Q 998 1184 998 1357 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-57" d="M 2016 595 
-Q 1798 595 1644 684 
-Q 1491 774 1398 918 
-Q 1306 1062 1264 1254 
-Q 1222 1446 1222 1645 
-Q 1222 1850 1260 2042 
-Q 1299 2234 1392 2381 
-Q 1485 2528 1635 2621 
-Q 1786 2714 2010 2714 
-Q 2227 2714 2377 2621 
-Q 2528 2528 2624 2377 
-Q 2720 2227 2761 2035 
-Q 2803 1843 2803 1645 
-Q 2803 1446 2764 1254 
-Q 2726 1062 2633 918 
-Q 2541 774 2390 684 
-Q 2240 595 2016 595 
+      <path id="HelveticaNeue-Bold-30" d="M 1043 2259 
+Q 1043 2374 1046 2537 
+Q 1050 2701 1069 2873 
+Q 1088 3046 1133 3216 
+Q 1178 3386 1258 3520 
+Q 1338 3654 1462 3737 
+Q 1587 3821 1773 3821 
+Q 1958 3821 2086 3737 
+Q 2214 3654 2297 3520 
+Q 2381 3386 2422 3216 
+Q 2464 3046 2486 2873 
+Q 2509 2701 2512 2537 
+Q 2515 2374 2515 2259 
+Q 2515 2067 2502 1795 
+Q 2490 1523 2422 1270 
+Q 2355 1018 2204 838 
+Q 2054 659 1773 659 
+Q 1498 659 1350 838 
+Q 1203 1018 1136 1270 
+Q 1069 1523 1056 1795 
+Q 1043 2067 1043 2259 
 z
-M 346 3309 
-L 346 -1158 
-L 1254 -1158 
-L 1254 410 
-L 1267 410 
-Q 1434 166 1693 41 
-Q 1952 -83 2259 -83 
-Q 2624 -83 2896 57 
-Q 3168 198 3350 435 
-Q 3533 672 3622 979 
-Q 3712 1286 3712 1619 
-Q 3712 1971 3622 2294 
-Q 3533 2618 3347 2861 
-Q 3162 3104 2880 3251 
-Q 2598 3398 2208 3398 
-Q 1901 3398 1645 3276 
-Q 1389 3155 1222 2886 
-L 1210 2886 
-L 1210 3309 
-L 346 3309 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-c4" d="M 544 2701 
-L 544 0 
-L 1453 0 
-L 1453 2701 
-L 2080 2701 
-L 2080 3309 
-L 1453 3309 
-L 1453 3507 
-Q 1453 3712 1533 3798 
-Q 1613 3885 1798 3885 
-Q 1971 3885 2131 3866 
-L 2131 4544 
-Q 2016 4550 1894 4560 
-Q 1773 4570 1651 4570 
-Q 1094 4570 819 4288 
-Q 544 4006 544 3565 
-L 544 3309 
-L 0 3309 
-L 0 2701 
-L 544 2701 
-z
-M 2630 3309 
-L 2630 0 
-L 3539 0 
-L 3539 3309 
-L 2630 3309 
-z
-M 3539 3821 
-L 3539 4570 
-L 2630 4570 
-L 2630 3821 
-L 3539 3821 
+M 134 2259 
+Q 134 1587 265 1136 
+Q 397 685 621 416 
+Q 845 147 1142 32 
+Q 1440 -83 1773 -83 
+Q 2112 -83 2409 32 
+Q 2707 147 2934 416 
+Q 3162 685 3293 1136 
+Q 3424 1587 3424 2259 
+Q 3424 2912 3293 3357 
+Q 3162 3802 2934 4070 
+Q 2707 4339 2409 4454 
+Q 2112 4570 1773 4570 
+Q 1440 4570 1142 4454 
+Q 845 4339 621 4070 
+Q 397 3802 265 3357 
+Q 134 2912 134 2259 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-53" d="M 371 4570 
-L 371 0 
-L 1280 0 
-L 1280 4570 
-L 371 4570 
+      <path id="HelveticaNeue-Bold-20" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-74" d="M 1498 3309 
+L 1498 4301 
+L 589 4301 
+L 589 3309 
+L 38 3309 
+L 38 2701 
+L 589 2701 
+L 589 749 
+Q 589 499 672 345 
+Q 755 192 899 109 
+Q 1043 26 1232 -3 
+Q 1421 -32 1632 -32 
+Q 1766 -32 1907 -25 
+Q 2048 -19 2163 0 
+L 2163 704 
+Q 2099 691 2028 684 
+Q 1958 678 1882 678 
+Q 1651 678 1574 755 
+Q 1498 832 1498 1062 
+L 1498 2701 
+L 2163 2701 
+L 2163 3309 
+L 1498 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-ed" d="M 410 595 
-L 896 109 
-L 1926 1139 
-L 2950 109 
-L 3437 595 
-L 2406 1619 
-L 3437 2643 
-L 2950 3130 
-L 1926 2106 
-L 909 3130 
-L 422 2643 
-L 1440 1619 
-L 410 595 
+      <path id="HelveticaNeue-Bold-6f" d="M 1152 1651 
+Q 1152 1850 1190 2042 
+Q 1229 2234 1321 2381 
+Q 1414 2528 1568 2621 
+Q 1722 2714 1952 2714 
+Q 2182 2714 2339 2621 
+Q 2496 2528 2589 2381 
+Q 2682 2234 2720 2042 
+Q 2758 1850 2758 1651 
+Q 2758 1453 2720 1264 
+Q 2682 1075 2589 924 
+Q 2496 774 2339 684 
+Q 2182 595 1952 595 
+Q 1722 595 1568 684 
+Q 1414 774 1321 924 
+Q 1229 1075 1190 1264 
+Q 1152 1453 1152 1651 
+z
+M 243 1651 
+Q 243 1254 364 934 
+Q 486 614 710 387 
+Q 934 160 1248 38 
+Q 1562 -83 1952 -83 
+Q 2342 -83 2659 38 
+Q 2976 160 3200 387 
+Q 3424 614 3545 934 
+Q 3667 1254 3667 1651 
+Q 3667 2048 3545 2371 
+Q 3424 2694 3200 2921 
+Q 2976 3149 2659 3273 
+Q 2342 3398 1952 3398 
+Q 1562 3398 1248 3273 
+Q 934 3149 710 2921 
+Q 486 2694 364 2371 
+Q 243 2048 243 1651 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-60" d="M 1978 -410 
-L 3360 3309 
-L 2419 3309 
-L 1696 1043 
-L 1683 1043 
-L 934 3309 
-L -32 3309 
-L 1126 205 
-Q 1165 109 1165 0 
-Q 1165 -147 1078 -268 
-Q 992 -390 813 -410 
-Q 678 -416 544 -403 
-Q 410 -390 282 -378 
-L 282 -1126 
-Q 422 -1139 560 -1148 
-Q 698 -1158 838 -1158 
-Q 1306 -1158 1568 -985 
-Q 1830 -813 1978 -410 
+      <path id="HelveticaNeue-Bold-6b" d="M 429 4570 
+L 429 0 
+L 1338 0 
+L 1338 1139 
+L 1690 1478 
+L 2598 0 
+L 3699 0 
+L 2310 2093 
+L 3558 3309 
+L 2483 3309 
+L 1338 2118 
+L 1338 4570 
+L 429 4570 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#HelveticaNeue-Bold-3b"/>
-     <use xlink:href="#HelveticaNeue-Bold-4f" transform="translate(61.09375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(120.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(177.796875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-32" transform="translate(205.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1a" transform="translate(277.796875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(333.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5a" transform="translate(361.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(414.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-59" transform="translate(472.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5d" transform="translate(511.203125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-50" transform="translate(563.203125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-55" transform="translate(589 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4e" transform="translate(648.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(709.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4d" transform="translate(737.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-59" transform="translate(770.484375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(807.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-55" transform="translate(868.6875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5b" transform="translate(927.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-50" transform="translate(963.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(988.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-59" transform="translate(1046.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-21" transform="translate(1085.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(1113.09375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4a" transform="translate(1140.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4f" transform="translate(1198.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5c" transform="translate(1257.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-55" transform="translate(1316.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-52" transform="translate(1376.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(1433.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4b" transform="translate(1491 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(1552.09375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(1579.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(1646.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1f" transform="translate(1713.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(1768.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-57" transform="translate(1796.6875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-59" transform="translate(1857.78125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(1894.890625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-c4" transform="translate(1952.296875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-53" transform="translate(2013.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-53" transform="translate(2039.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(2064.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-ed" transform="translate(2092.78125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(2152.78125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4b" transform="translate(2180.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(2241.671875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4a" transform="translate(2299.078125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(2356.484375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4b" transform="translate(2417.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(2478.671875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(2536.078125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5b" transform="translate(2563.875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(2599.078125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-57" transform="translate(2660.171875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(2721.265625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-53" transform="translate(2782.359375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(2808.15625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4e" transform="translate(2869.25 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-60" transform="translate(2930.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 2,633 tok/s/GPU @ 18.4 tok/s/user -->
-    <g style="fill: #52514e" transform="translate(157.10176 104.472177) scale(0.095 -0.095)">
-     <defs>
-      <path id="HelveticaNeue-Bold-19" d="M 237 2758 
-L 1107 2758 
-Q 1107 2938 1142 3120 
-Q 1178 3302 1261 3452 
-Q 1344 3603 1481 3696 
-Q 1619 3789 1818 3789 
-Q 2112 3789 2301 3606 
-Q 2490 3424 2490 3098 
-Q 2490 2893 2397 2733 
-Q 2304 2573 2166 2445 
-Q 2029 2317 1862 2211 
-Q 1696 2106 1549 2003 
-Q 1261 1805 1001 1613 
-Q 742 1421 550 1193 
-Q 358 966 246 678 
-Q 134 390 134 0 
-L 3424 0 
-L 3424 781 
-L 1306 781 
-Q 1472 1011 1689 1184 
-Q 1907 1357 2137 1507 
-Q 2368 1658 2595 1811 
-Q 2822 1965 3001 2153 
-Q 3181 2342 3289 2585 
-Q 3398 2829 3398 3168 
-Q 3398 3494 3273 3756 
-Q 3149 4019 2937 4198 
-Q 2726 4378 2448 4474 
-Q 2170 4570 1862 4570 
-Q 1459 4570 1148 4432 
-Q 838 4294 633 4048 
-Q 429 3802 326 3472 
-Q 224 3142 237 2758 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-13" d="M 390 986 
-L 390 0 
-L 851 0 
-Q 858 -102 826 -201 
-Q 794 -301 730 -381 
-Q 666 -461 579 -518 
-Q 493 -576 397 -595 
-L 397 -1056 
-Q 602 -1024 784 -937 
-Q 966 -851 1100 -716 
-Q 1235 -582 1315 -400 
-Q 1395 -218 1395 0 
-L 1395 986 
-L 390 986 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-1d" d="M 1830 2323 
-Q 2003 2323 2134 2249 
-Q 2266 2176 2349 2057 
-Q 2432 1939 2473 1788 
-Q 2515 1638 2515 1478 
-Q 2515 1325 2470 1177 
-Q 2426 1030 2336 915 
-Q 2246 800 2121 729 
-Q 1997 659 1830 659 
-Q 1658 659 1523 729 
-Q 1389 800 1296 918 
-Q 1203 1037 1155 1187 
-Q 1107 1338 1107 1491 
-Q 1107 1658 1152 1808 
-Q 1197 1958 1286 2073 
-Q 1376 2189 1513 2256 
-Q 1651 2323 1830 2323 
-z
-M 2483 3328 
-L 3347 3328 
-Q 3309 3629 3187 3859 
-Q 3066 4090 2874 4246 
-Q 2682 4403 2432 4486 
-Q 2182 4570 1894 4570 
-Q 1414 4570 1081 4358 
-Q 749 4147 537 3811 
-Q 326 3475 230 3059 
-Q 134 2643 134 2227 
-Q 134 1798 211 1385 
-Q 288 973 486 646 
-Q 685 320 1017 118 
-Q 1350 -83 1856 -83 
-Q 2208 -83 2496 41 
-Q 2784 166 2992 387 
-Q 3200 608 3312 905 
-Q 3424 1203 3424 1549 
-Q 3424 1818 3341 2080 
-Q 3258 2342 3078 2547 
-Q 2886 2758 2611 2883 
-Q 2336 3008 2048 3008 
-Q 1722 3008 1472 2893 
-Q 1222 2778 1037 2509 
-L 1024 2522 
-Q 1030 2707 1075 2944 
-Q 1120 3181 1216 3389 
-Q 1312 3597 1475 3741 
-Q 1638 3885 1882 3885 
-Q 2118 3885 2278 3718 
-Q 2438 3552 2483 3328 
-z
-" transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-16" d="M 1715 4678 
+      <path id="HelveticaNeue-Bold-2f" d="M 1715 4678 
 L -64 -102 
 L 659 -102 
 L 2445 4678 
 L 1715 4678 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-2e" d="M 3744 518 
+      <path id="HelveticaNeue-Bold-73" d="M 1050 1075 
+L 186 1075 
+Q 198 742 336 521 
+Q 474 301 688 166 
+Q 902 32 1177 -25 
+Q 1453 -83 1741 -83 
+Q 2022 -83 2294 -28 
+Q 2566 26 2777 160 
+Q 2989 294 3120 515 
+Q 3251 736 3251 1062 
+Q 3251 1293 3161 1449 
+Q 3072 1606 2925 1712 
+Q 2778 1818 2589 1882 
+Q 2400 1946 2202 1990 
+Q 2010 2035 1824 2073 
+Q 1638 2112 1494 2160 
+Q 1350 2208 1260 2285 
+Q 1171 2362 1171 2483 
+Q 1171 2586 1222 2646 
+Q 1274 2707 1347 2739 
+Q 1421 2771 1510 2780 
+Q 1600 2790 1677 2790 
+Q 1920 2790 2099 2697 
+Q 2278 2605 2298 2342 
+L 3162 2342 
+Q 3136 2650 3005 2851 
+Q 2874 3053 2675 3174 
+Q 2477 3296 2224 3347 
+Q 1971 3398 1702 3398 
+Q 1434 3398 1178 3350 
+Q 922 3302 717 3184 
+Q 512 3066 387 2861 
+Q 262 2656 262 2336 
+Q 262 2118 352 1968 
+Q 442 1818 589 1718 
+Q 736 1619 925 1558 
+Q 1114 1498 1312 1453 
+Q 1798 1350 2070 1248 
+Q 2342 1146 2342 941 
+Q 2342 819 2284 739 
+Q 2227 659 2140 611 
+Q 2054 563 1948 540 
+Q 1843 518 1747 518 
+Q 1613 518 1488 550 
+Q 1363 582 1267 649 
+Q 1171 717 1110 822 
+Q 1050 928 1050 1075 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-47" d="M 3744 518 
 L 3846 0 
 L 4486 0 
 L 4486 2470 
@@ -3077,7 +2424,36 @@ Q 2822 -102 3148 35
 Q 3475 173 3744 518 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-3c" d="M 4320 1728 
+      <path id="HelveticaNeue-Bold-50" d="M 1446 2419 
+L 1446 3789 
+L 2227 3789 
+Q 2400 3789 2560 3763 
+Q 2720 3738 2841 3664 
+Q 2963 3590 3036 3456 
+Q 3110 3322 3110 3104 
+Q 3110 2886 3036 2752 
+Q 2963 2618 2841 2544 
+Q 2720 2470 2560 2444 
+Q 2400 2419 2227 2419 
+L 1446 2419 
+z
+M 442 4570 
+L 442 0 
+L 1446 0 
+L 1446 1638 
+L 2502 1638 
+Q 2931 1638 3232 1763 
+Q 3533 1888 3721 2093 
+Q 3910 2298 3996 2563 
+Q 4083 2829 4083 3104 
+Q 4083 3386 3996 3648 
+Q 3910 3910 3721 4115 
+Q 3533 4320 3232 4445 
+Q 2931 4570 2502 4570 
+L 442 4570 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-55" d="M 4320 1728 
 L 4320 4570 
 L 3315 4570 
 L 3315 1728 
@@ -3096,7 +2472,7 @@ Q 3283 -102 3801 349
 Q 4320 800 4320 1728 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-27" d="M 3578 1837 
+      <path id="HelveticaNeue-Bold-40" d="M 3578 1837 
 L 3981 3488 
 L 3456 3488 
 L 3354 3142 
@@ -3172,7 +2548,7 @@ Q 2138 1472 2000 1629
 Q 1862 1786 1862 2042 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-18" d="M 2509 0 
+      <path id="HelveticaNeue-Bold-31" d="M 2509 0 
 L 2509 4480 
 L 1786 4480 
 Q 1747 4224 1625 4051 
@@ -3185,85 +2561,193 @@ L 1600 0
 L 2509 0 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-15" d="M 384 986 
+      <path id="HelveticaNeue-Bold-2e" d="M 384 986 
 L 384 0 
 L 1389 0 
 L 1389 986 
 L 384 986 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-1b" d="M 1997 3341 
-L 1997 1786 
-L 819 1786 
-L 1978 3341 
-L 1997 3341 
+      <path id="HelveticaNeue-Bold-37" d="M 3309 3699 
+L 3309 4480 
+L 250 4480 
+L 250 3635 
+L 2374 3635 
+Q 1734 2861 1340 1933 
+Q 947 1005 870 0 
+L 1843 0 
+Q 1850 448 1949 966 
+Q 2048 1485 2230 1990 
+Q 2413 2496 2685 2944 
+Q 2957 3392 3309 3699 
 z
-M 1997 1037 
-L 1997 0 
-L 2861 0 
-L 2861 1037 
-L 3456 1037 
-L 3456 1786 
-L 2861 1786 
-L 2861 4480 
-L 2048 4480 
-L 102 1869 
-L 102 1037 
-L 1997 1037 
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-75" d="M 3450 0 
+L 3450 3309 
+L 2541 3309 
+L 2541 1574 
+Q 2541 1069 2374 848 
+Q 2208 627 1837 627 
+Q 1510 627 1382 828 
+Q 1254 1030 1254 1440 
+L 1254 3309 
+L 346 3309 
+L 346 1274 
+Q 346 966 400 713 
+Q 454 461 588 285 
+Q 723 109 956 13 
+Q 1190 -83 1555 -83 
+Q 1843 -83 2118 45 
+Q 2394 173 2566 461 
+L 2586 461 
+L 2586 0 
+L 3450 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-65" d="M 2573 2010 
+L 1094 2010 
+Q 1101 2106 1136 2227 
+Q 1171 2349 1257 2457 
+Q 1344 2566 1488 2640 
+Q 1632 2714 1850 2714 
+Q 2182 2714 2345 2534 
+Q 2509 2355 2573 2010 
+z
+M 1094 1434 
+L 3482 1434 
+Q 3507 1818 3417 2170 
+Q 3328 2522 3126 2797 
+Q 2925 3072 2611 3235 
+Q 2298 3398 1875 3398 
+Q 1498 3398 1187 3264 
+Q 877 3130 653 2896 
+Q 429 2662 307 2342 
+Q 186 2022 186 1651 
+Q 186 1267 304 947 
+Q 422 627 640 396 
+Q 858 166 1171 41 
+Q 1485 -83 1875 -83 
+Q 2438 -83 2835 173 
+Q 3232 429 3424 1024 
+L 2624 1024 
+Q 2579 870 2380 732 
+Q 2182 595 1907 595 
+Q 1523 595 1318 793 
+Q 1114 992 1094 1434 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-72" d="M 346 3309 
+L 346 0 
+L 1254 0 
+L 1254 1491 
+Q 1254 1715 1299 1907 
+Q 1344 2099 1449 2243 
+Q 1555 2387 1728 2470 
+Q 1901 2554 2150 2554 
+Q 2234 2554 2323 2544 
+Q 2413 2534 2477 2522 
+L 2477 3366 
+Q 2368 3398 2278 3398 
+Q 2106 3398 1946 3347 
+Q 1786 3296 1645 3203 
+Q 1504 3110 1395 2979 
+Q 1286 2848 1222 2694 
+L 1210 2694 
+L 1210 3309 
+L 346 3309 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#HelveticaNeue-Bold-19"/>
-     <use xlink:href="#HelveticaNeue-Bold-13" transform="translate(55.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1d" transform="translate(83.390625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1a" transform="translate(138.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1a" transform="translate(194.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(250.171875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5b" transform="translate(277.96875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(313.171875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-52" transform="translate(374.265625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-16" transform="translate(431.671875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5a" transform="translate(468.765625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-16" transform="translate(522.46875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-2e" transform="translate(559.5625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(635.46875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3c" transform="translate(702.171875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(776.265625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-27" transform="translate(804.0625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(884.0625 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-18" transform="translate(911.859375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1f" transform="translate(967.453125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-15" transform="translate(1023.046875 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1b" transform="translate(1050.84375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(1106.4375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5b" transform="translate(1134.234375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(1169.4375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-52" transform="translate(1230.53125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-16" transform="translate(1287.9375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5a" transform="translate(1325.03125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-16" transform="translate(1378.734375 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5c" transform="translate(1415.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-5a" transform="translate(1475.125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4c" transform="translate(1528.828125 0)"/>
-     <use xlink:href="#HelveticaNeue-Bold-59" transform="translate(1586.234375 0)"/>
+     <use xlink:href="#HelveticaNeue-Bold-32"/>
+     <use xlink:href="#HelveticaNeue-Bold-2c" x="55.599991"/>
+     <use xlink:href="#HelveticaNeue-Bold-38" x="83.399979"/>
+     <use xlink:href="#HelveticaNeue-Bold-30" x="138.999969"/>
+     <use xlink:href="#HelveticaNeue-Bold-38" x="194.59996"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="250.199951"/>
+     <use xlink:href="#HelveticaNeue-Bold-74" x="277.999939"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="313.199936"/>
+     <use xlink:href="#HelveticaNeue-Bold-6b" x="374.299927"/>
+     <use xlink:href="#HelveticaNeue-Bold-2f" x="431.699921"/>
+     <use xlink:href="#HelveticaNeue-Bold-73" x="468.799911"/>
+     <use xlink:href="#HelveticaNeue-Bold-2f" x="522.499908"/>
+     <use xlink:href="#HelveticaNeue-Bold-47" x="559.599899"/>
+     <use xlink:href="#HelveticaNeue-Bold-50" x="635.499893"/>
+     <use xlink:href="#HelveticaNeue-Bold-55" x="702.19989"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="776.299881"/>
+     <use xlink:href="#HelveticaNeue-Bold-40" x="804.099869"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="884.099854"/>
+     <use xlink:href="#HelveticaNeue-Bold-31" x="911.899841"/>
+     <use xlink:href="#HelveticaNeue-Bold-38" x="967.499832"/>
+     <use xlink:href="#HelveticaNeue-Bold-2e" x="1023.099823"/>
+     <use xlink:href="#HelveticaNeue-Bold-37" x="1050.899811"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1106.499802"/>
+     <use xlink:href="#HelveticaNeue-Bold-74" x="1134.299789"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="1169.499786"/>
+     <use xlink:href="#HelveticaNeue-Bold-6b" x="1230.599777"/>
+     <use xlink:href="#HelveticaNeue-Bold-2f" x="1287.999771"/>
+     <use xlink:href="#HelveticaNeue-Bold-73" x="1325.099762"/>
+     <use xlink:href="#HelveticaNeue-Bold-2f" x="1378.799759"/>
+     <use xlink:href="#HelveticaNeue-Bold-75" x="1415.89975"/>
+     <use xlink:href="#HelveticaNeue-Bold-73" x="1475.199738"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="1528.899734"/>
+     <use xlink:href="#HelveticaNeue-Bold-72" x="1586.299728"/>
     </g>
-    <!-- 2×PP8 $\to$ 2×DCP8, conc 2048 -->
-    <g style="fill: #52514e" transform="translate(157.10176 116.071677) scale(0.095 -0.095)">
+    <!-- PP8 → TP8 (1P:1D) fp4, conc 1024 -->
+    <g style="fill: #1a1b1d" transform="translate(175.641071 105.726434) scale(0.095 -0.095)">
      <defs>
-      <path id="DejaVuSans-c1c" d="M 5050 2147 
-L 5050 1866 
-L 3822 638 
-L 3447 1013 
-L 4175 1741 
-L 366 1741 
-L 366 2272 
-L 4175 2272 
-L 3447 3000 
-L 3822 3375 
-L 5050 2147 
+      <path id="DejaVuSans-Bold-2192" d="M 5050 2225 
+L 5050 1788 
+L 3822 559 
+L 3369 1013 
+L 3988 1631 
+L 366 1631 
+L 366 2381 
+L 3988 2381 
+L 3369 3000 
+L 3822 3453 
+L 5050 2225 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-2b" d="M 1446 845 
+      <path id="HelveticaNeue-Bold-54" d="M 1453 3725 
+L 1453 0 
+L 2458 0 
+L 2458 3725 
+L 3827 3725 
+L 3827 4570 
+L 83 4570 
+L 83 3725 
+L 1453 3725 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-28" d="M 1939 4678 
+L 1178 4678 
+Q 966 4371 809 4006 
+Q 653 3642 547 3251 
+Q 442 2861 387 2467 
+Q 333 2074 333 1715 
+Q 333 960 553 230 
+Q 774 -499 1178 -1158 
+L 1933 -1158 
+Q 1568 -461 1405 275 
+Q 1242 1011 1242 1779 
+Q 1242 2534 1408 3267 
+Q 1574 4000 1939 4678 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-3a" d="M 1395 2266 
+L 1395 3251 
+L 390 3251 
+L 390 2266 
+L 1395 2266 
+z
+M 390 986 
+L 390 0 
+L 1395 0 
+L 1395 986 
+L 390 986 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-44" d="M 1446 845 
 L 1446 3725 
 L 2163 3725 
 Q 2534 3725 2787 3619 
@@ -3290,155 +2774,271 @@ Q 2854 4570 2413 4570
 L 442 4570 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-2a" d="M 3488 3034 
-L 4461 3034 
-Q 4416 3430 4243 3737 
-Q 4070 4045 3804 4253 
-Q 3539 4461 3203 4569 
-Q 2867 4678 2490 4678 
-Q 1965 4678 1545 4492 
-Q 1126 4307 838 3980 
-Q 550 3654 396 3216 
-Q 243 2778 243 2266 
-Q 243 1766 396 1334 
-Q 550 902 838 582 
-Q 1126 262 1545 80 
-Q 1965 -102 2490 -102 
-Q 2912 -102 3264 26 
-Q 3616 154 3878 397 
-Q 4141 640 4301 985 
-Q 4461 1331 4499 1760 
-L 3526 1760 
-Q 3469 1299 3209 1017 
-Q 2950 736 2490 736 
-Q 2150 736 1913 867 
-Q 1677 998 1529 1216 
-Q 1382 1434 1315 1706 
-Q 1248 1978 1248 2266 
-Q 1248 2566 1315 2848 
-Q 1382 3130 1529 3350 
-Q 1677 3571 1913 3702 
-Q 2150 3834 2490 3834 
-Q 2675 3834 2844 3773 
-Q 3014 3712 3148 3603 
-Q 3283 3494 3372 3350 
-Q 3462 3206 3488 3034 
+      <path id="HelveticaNeue-Bold-29" d="M -38 -1158 
+L 717 -1158 
+Q 928 -858 1088 -493 
+Q 1248 -128 1353 259 
+Q 1459 646 1510 1040 
+Q 1562 1434 1562 1792 
+Q 1562 2547 1341 3283 
+Q 1120 4019 717 4678 
+L -32 4678 
+Q 320 3981 486 3238 
+Q 653 2496 653 1728 
+Q 653 973 483 246 
+Q 314 -480 -38 -1158 
 z
 " transform="scale(0.015625)"/>
-      <path id="HelveticaNeue-Bold-17" d="M 1043 2259 
-Q 1043 2374 1046 2537 
-Q 1050 2701 1069 2873 
-Q 1088 3046 1133 3216 
-Q 1178 3386 1258 3520 
-Q 1338 3654 1462 3737 
-Q 1587 3821 1773 3821 
-Q 1958 3821 2086 3737 
-Q 2214 3654 2297 3520 
-Q 2381 3386 2422 3216 
-Q 2464 3046 2486 2873 
-Q 2509 2701 2512 2537 
-Q 2515 2374 2515 2259 
-Q 2515 2067 2502 1795 
-Q 2490 1523 2422 1270 
-Q 2355 1018 2204 838 
-Q 2054 659 1773 659 
-Q 1498 659 1350 838 
-Q 1203 1018 1136 1270 
-Q 1069 1523 1056 1795 
-Q 1043 2067 1043 2259 
+      <path id="HelveticaNeue-Bold-66" d="M 544 2701 
+L 544 0 
+L 1453 0 
+L 1453 2701 
+L 2080 2701 
+L 2080 3309 
+L 1453 3309 
+L 1453 3507 
+Q 1453 3712 1533 3798 
+Q 1613 3885 1798 3885 
+Q 1971 3885 2131 3866 
+L 2131 4544 
+Q 2016 4550 1894 4560 
+Q 1773 4570 1651 4570 
+Q 1094 4570 819 4288 
+Q 544 4006 544 3565 
+L 544 3309 
+L 0 3309 
+L 0 2701 
+L 544 2701 
 z
-M 134 2259 
-Q 134 1587 265 1136 
-Q 397 685 621 416 
-Q 845 147 1142 32 
-Q 1440 -83 1773 -83 
-Q 2112 -83 2409 32 
-Q 2707 147 2934 416 
-Q 3162 685 3293 1136 
-Q 3424 1587 3424 2259 
-Q 3424 2912 3293 3357 
-Q 3162 3802 2934 4070 
-Q 2707 4339 2409 4454 
-Q 2112 4570 1773 4570 
-Q 1440 4570 1142 4454 
-Q 845 4339 621 4070 
-Q 397 3802 265 3357 
-Q 134 2912 134 2259 
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-70" d="M 2016 595 
+Q 1798 595 1644 684 
+Q 1491 774 1398 918 
+Q 1306 1062 1264 1254 
+Q 1222 1446 1222 1645 
+Q 1222 1850 1260 2042 
+Q 1299 2234 1392 2381 
+Q 1485 2528 1635 2621 
+Q 1786 2714 2010 2714 
+Q 2227 2714 2377 2621 
+Q 2528 2528 2624 2377 
+Q 2720 2227 2761 2035 
+Q 2803 1843 2803 1645 
+Q 2803 1446 2764 1254 
+Q 2726 1062 2633 918 
+Q 2541 774 2390 684 
+Q 2240 595 2016 595 
+z
+M 346 3309 
+L 346 -1158 
+L 1254 -1158 
+L 1254 410 
+L 1267 410 
+Q 1434 166 1693 41 
+Q 1952 -83 2259 -83 
+Q 2624 -83 2896 57 
+Q 3168 198 3350 435 
+Q 3533 672 3622 979 
+Q 3712 1286 3712 1619 
+Q 3712 1971 3622 2294 
+Q 3533 2618 3347 2861 
+Q 3162 3104 2880 3251 
+Q 2598 3398 2208 3398 
+Q 1901 3398 1645 3276 
+Q 1389 3155 1222 2886 
+L 1210 2886 
+L 1210 3309 
+L 346 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-34" d="M 1997 3341 
+L 1997 1786 
+L 819 1786 
+L 1978 3341 
+L 1997 3341 
+z
+M 1997 1037 
+L 1997 0 
+L 2861 0 
+L 2861 1037 
+L 3456 1037 
+L 3456 1786 
+L 2861 1786 
+L 2861 4480 
+L 2048 4480 
+L 102 1869 
+L 102 1037 
+L 1997 1037 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-63" d="M 2598 2144 
+L 3488 2144 
+Q 3469 2464 3334 2697 
+Q 3200 2931 2985 3088 
+Q 2771 3245 2499 3321 
+Q 2227 3398 1933 3398 
+Q 1530 3398 1216 3264 
+Q 902 3130 684 2890 
+Q 467 2650 355 2320 
+Q 243 1990 243 1606 
+Q 243 1235 364 924 
+Q 486 614 704 390 
+Q 922 166 1232 41 
+Q 1542 -83 1914 -83 
+Q 2573 -83 2995 262 
+Q 3418 608 3507 1267 
+L 2630 1267 
+Q 2586 960 2410 777 
+Q 2234 595 1907 595 
+Q 1696 595 1549 691 
+Q 1402 787 1315 937 
+Q 1229 1088 1190 1273 
+Q 1152 1459 1152 1638 
+Q 1152 1824 1190 2013 
+Q 1229 2202 1321 2358 
+Q 1414 2515 1561 2614 
+Q 1709 2714 1926 2714 
+Q 2509 2714 2598 2144 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-6e" d="M 346 3309 
+L 346 0 
+L 1254 0 
+L 1254 1734 
+Q 1254 2240 1420 2461 
+Q 1587 2682 1958 2682 
+Q 2285 2682 2413 2480 
+Q 2541 2278 2541 1869 
+L 2541 0 
+L 3450 0 
+L 3450 2035 
+Q 3450 2342 3395 2595 
+Q 3341 2848 3206 3024 
+Q 3072 3200 2838 3299 
+Q 2605 3398 2240 3398 
+Q 1952 3398 1677 3267 
+Q 1402 3136 1229 2848 
+L 1210 2848 
+L 1210 3309 
+L 346 3309 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#HelveticaNeue-Bold-19" transform="translate(0 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-ed" transform="translate(55.599945 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(115.599884 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(182.29982 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1f" transform="translate(248.999756 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(304.599701 0.90625)"/>
-     <use xlink:href="#DejaVuSans-c1c" transform="translate(351.882095 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(455.15358 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-19" transform="translate(482.953552 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-ed" transform="translate(538.553497 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-2b" transform="translate(598.553436 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-2a" transform="translate(672.653366 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-37" transform="translate(746.753296 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1f" transform="translate(813.453232 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-13" transform="translate(869.053177 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(896.853149 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4a" transform="translate(924.653122 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-56" transform="translate(982.05307 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-55" transform="translate(1043.153015 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-4a" transform="translate(1102.452957 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-3" transform="translate(1159.852905 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-19" transform="translate(1187.652878 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-17" transform="translate(1243.252823 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1b" transform="translate(1298.852768 0.90625)"/>
-     <use xlink:href="#HelveticaNeue-Bold-1f" transform="translate(1354.452713 0.90625)"/>
+     <use xlink:href="#HelveticaNeue-Bold-50"/>
+     <use xlink:href="#HelveticaNeue-Bold-50" x="66.699997"/>
+     <use xlink:href="#HelveticaNeue-Bold-38" x="133.399994"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="188.999985"/>
+     <use xlink:href="#DejaVuSans-Bold-2192" x="216.799973"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="300.589035"/>
+     <use xlink:href="#HelveticaNeue-Bold-54" x="328.389023"/>
+     <use xlink:href="#HelveticaNeue-Bold-50" x="389.489014"/>
+     <use xlink:href="#HelveticaNeue-Bold-38" x="456.189011"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="511.789001"/>
+     <use xlink:href="#HelveticaNeue-Bold-28" x="539.588989"/>
+     <use xlink:href="#HelveticaNeue-Bold-31" x="569.18898"/>
+     <use xlink:href="#HelveticaNeue-Bold-50" x="624.788971"/>
+     <use xlink:href="#HelveticaNeue-Bold-3a" x="691.488968"/>
+     <use xlink:href="#HelveticaNeue-Bold-31" x="719.288956"/>
+     <use xlink:href="#HelveticaNeue-Bold-44" x="774.888947"/>
+     <use xlink:href="#HelveticaNeue-Bold-29" x="848.988937"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="878.588928"/>
+     <use xlink:href="#HelveticaNeue-Bold-66" x="906.388916"/>
+     <use xlink:href="#HelveticaNeue-Bold-70" x="939.688904"/>
+     <use xlink:href="#HelveticaNeue-Bold-34" x="1000.788895"/>
+     <use xlink:href="#HelveticaNeue-Bold-2c" x="1056.388885"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1084.188873"/>
+     <use xlink:href="#HelveticaNeue-Bold-63" x="1111.988861"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="1169.388855"/>
+     <use xlink:href="#HelveticaNeue-Bold-6e" x="1230.488846"/>
+     <use xlink:href="#HelveticaNeue-Bold-63" x="1289.788834"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1347.188828"/>
+     <use xlink:href="#HelveticaNeue-Bold-31" x="1374.988815"/>
+     <use xlink:href="#HelveticaNeue-Bold-30" x="1430.588806"/>
+     <use xlink:href="#HelveticaNeue-Bold-32" x="1486.188797"/>
+     <use xlink:href="#HelveticaNeue-Bold-34" x="1541.788788"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- PP8 $\to$ 4×TP8, conc 32 -->
-    <g style="fill: #52514e" transform="translate(617.537946 324.579976) scale(0.095 -0.095)">
+   <g id="text_24">
+    <!-- TP8 → 3×TP8 (1P:3D) fp4, conc 1 -->
+    <g style="fill: #52514e" transform="translate(612.796279 334.489784) scale(0.095 -0.095)">
      <defs>
-      <path id="HelveticaNeue-ed" d="M 454 461 
-L 762 154 
-L 1926 1318 
-L 3085 154 
-L 3392 461 
-L 2234 1626 
-L 3386 2778 
-L 3078 3085 
-L 1926 1933 
-L 768 3085 
-L 461 2778 
-L 1619 1626 
-L 454 461 
+      <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-3a" d="M 1242 2598 
+L 1242 3309 
+L 531 3309 
+L 531 2598 
+L 1242 2598 
+z
+M 531 710 
+L 531 0 
+L 1242 0 
+L 1242 710 
+L 531 710 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-2c" d="M 531 710 
+L 531 0 
+L 909 0 
+Q 915 -77 899 -166 
+Q 883 -256 838 -342 
+Q 794 -429 720 -502 
+Q 646 -576 538 -614 
+L 538 -934 
+Q 909 -826 1075 -563 
+Q 1242 -301 1242 64 
+L 1242 710 
+L 531 710 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-     <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-1b" transform="translate(363.55368 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-ed" transform="translate(419.153625 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-3b" transform="translate(479.153564 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-37" transform="translate(536.553513 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-1f" transform="translate(601.353455 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-13" transform="translate(656.9534 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(684.753372 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-4a" transform="translate(712.553345 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(766.253296 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-55" transform="translate(823.653244 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-4a" transform="translate(879.253189 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(932.95314 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-1a" transform="translate(960.753113 0.59375)"/>
-     <use xlink:href="#HelveticaNeue-19" transform="translate(1016.353058 0.59375)"/>
+     <use xlink:href="#HelveticaNeue-54"/>
+     <use xlink:href="#HelveticaNeue-50" x="57.399994"/>
+     <use xlink:href="#HelveticaNeue-38" x="122.199982"/>
+     <use xlink:href="#HelveticaNeue-20" x="177.799973"/>
+     <use xlink:href="#DejaVuSans-2192" x="205.59996"/>
+     <use xlink:href="#HelveticaNeue-20" x="289.389023"/>
+     <use xlink:href="#HelveticaNeue-33" x="317.189011"/>
+     <use xlink:href="#HelveticaNeue-d7" x="372.789001"/>
+     <use xlink:href="#HelveticaNeue-54" x="432.788986"/>
+     <use xlink:href="#HelveticaNeue-50" x="490.18898"/>
+     <use xlink:href="#HelveticaNeue-38" x="554.988968"/>
+     <use xlink:href="#HelveticaNeue-20" x="610.588959"/>
+     <use xlink:href="#HelveticaNeue-28" x="638.388947"/>
+     <use xlink:href="#HelveticaNeue-31" x="664.28894"/>
+     <use xlink:href="#HelveticaNeue-50" x="719.888931"/>
+     <use xlink:href="#HelveticaNeue-3a" x="784.688919"/>
+     <use xlink:href="#HelveticaNeue-33" x="812.488907"/>
+     <use xlink:href="#HelveticaNeue-44" x="868.088898"/>
+     <use xlink:href="#HelveticaNeue-29" x="938.488892"/>
+     <use xlink:href="#HelveticaNeue-20" x="964.388885"/>
+     <use xlink:href="#HelveticaNeue-66" x="992.188873"/>
+     <use xlink:href="#HelveticaNeue-70" x="1021.788864"/>
+     <use xlink:href="#HelveticaNeue-34" x="1081.088852"/>
+     <use xlink:href="#HelveticaNeue-2c" x="1136.688843"/>
+     <use xlink:href="#HelveticaNeue-20" x="1164.488831"/>
+     <use xlink:href="#HelveticaNeue-63" x="1192.288818"/>
+     <use xlink:href="#HelveticaNeue-6f" x="1245.988815"/>
+     <use xlink:href="#HelveticaNeue-6e" x="1303.388809"/>
+     <use xlink:href="#HelveticaNeue-63" x="1358.9888"/>
+     <use xlink:href="#HelveticaNeue-20" x="1412.688797"/>
+     <use xlink:href="#HelveticaNeue-31" x="1440.488785"/>
     </g>
-    <!-- 86.8 tok/s/user -->
-    <g style="fill: #52514e" transform="translate(655.502321 335.913476) scale(0.095 -0.095)">
+    <!-- 115.8 tok/s/user -->
+    <g style="fill: #52514e" transform="translate(685.763701 346.536972) scale(0.095 -0.095)">
      <defs>
-      <path id="HelveticaNeue-15" d="M 531 710 
+      <path id="HelveticaNeue-2e" d="M 531 710 
 L 531 0 
 L 1242 0 
 L 1242 710 
@@ -3446,53 +3046,359 @@ L 531 710
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#HelveticaNeue-1f"/>
-     <use xlink:href="#HelveticaNeue-1d" transform="translate(55.59375 0)"/>
-     <use xlink:href="#HelveticaNeue-15" transform="translate(111.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-1f" transform="translate(138.984375 0)"/>
-     <use xlink:href="#HelveticaNeue-3" transform="translate(194.578125 0)"/>
-     <use xlink:href="#HelveticaNeue-5b" transform="translate(222.375 0)"/>
-     <use xlink:href="#HelveticaNeue-56" transform="translate(253.875 0)"/>
-     <use xlink:href="#HelveticaNeue-52" transform="translate(311.28125 0)"/>
-     <use xlink:href="#HelveticaNeue-16" transform="translate(363.1875 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(396.484375 0)"/>
-     <use xlink:href="#HelveticaNeue-16" transform="translate(446.484375 0)"/>
-     <use xlink:href="#HelveticaNeue-5c" transform="translate(479.78125 0)"/>
-     <use xlink:href="#HelveticaNeue-5a" transform="translate(535.375 0)"/>
-     <use xlink:href="#HelveticaNeue-4c" transform="translate(585.375 0)"/>
-     <use xlink:href="#HelveticaNeue-59" transform="translate(639.078125 0)"/>
+     <use xlink:href="#HelveticaNeue-31"/>
+     <use xlink:href="#HelveticaNeue-31" x="55.599991"/>
+     <use xlink:href="#HelveticaNeue-35" x="111.199982"/>
+     <use xlink:href="#HelveticaNeue-2e" x="166.799973"/>
+     <use xlink:href="#HelveticaNeue-38" x="194.59996"/>
+     <use xlink:href="#HelveticaNeue-20" x="250.199951"/>
+     <use xlink:href="#HelveticaNeue-74" x="277.999939"/>
+     <use xlink:href="#HelveticaNeue-6f" x="309.499924"/>
+     <use xlink:href="#HelveticaNeue-6b" x="366.899918"/>
+     <use xlink:href="#HelveticaNeue-2f" x="418.799911"/>
+     <use xlink:href="#HelveticaNeue-73" x="452.099899"/>
+     <use xlink:href="#HelveticaNeue-2f" x="502.099884"/>
+     <use xlink:href="#HelveticaNeue-75" x="535.399872"/>
+     <use xlink:href="#HelveticaNeue-73" x="590.999863"/>
+     <use xlink:href="#HelveticaNeue-65" x="640.999847"/>
+     <use xlink:href="#HelveticaNeue-72" x="694.699844"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- The K3 serving frontier: prefill × decode topology -->
+    <g style="fill: #1a1b1d" transform="translate(53.1648 15.387969) scale(0.155 -0.155)">
+     <defs>
+      <path id="HelveticaNeue-Bold-68" d="M 346 4570 
+L 346 0 
+L 1254 0 
+L 1254 1734 
+Q 1254 2240 1420 2461 
+Q 1587 2682 1958 2682 
+Q 2285 2682 2413 2480 
+Q 2541 2278 2541 1869 
+L 2541 0 
+L 3450 0 
+L 3450 2035 
+Q 3450 2342 3395 2595 
+Q 3341 2848 3206 3024 
+Q 3072 3200 2838 3299 
+Q 2605 3398 2240 3398 
+Q 1984 3398 1715 3267 
+Q 1446 3136 1274 2848 
+L 1254 2848 
+L 1254 4570 
+L 346 4570 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-4b" d="M 442 4570 
+L 442 0 
+L 1446 0 
+L 1446 1472 
+L 2022 2054 
+L 3398 0 
+L 4659 0 
+L 2701 2765 
+L 4486 4570 
+L 3232 4570 
+L 1446 2675 
+L 1446 4570 
+L 442 4570 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-33" d="M 1459 2669 
+L 1459 2029 
+Q 1626 2029 1808 2019 
+Q 1990 2010 2144 1949 
+Q 2298 1888 2397 1753 
+Q 2496 1619 2496 1363 
+Q 2496 1037 2285 848 
+Q 2074 659 1766 659 
+Q 1568 659 1424 729 
+Q 1280 800 1184 918 
+Q 1088 1037 1037 1200 
+Q 986 1363 979 1542 
+L 115 1542 
+Q 109 1152 227 851 
+Q 346 550 563 342 
+Q 781 134 1091 25 
+Q 1402 -83 1779 -83 
+Q 2106 -83 2406 13 
+Q 2707 109 2937 294 
+Q 3168 480 3305 755 
+Q 3443 1030 3443 1382 
+Q 3443 1766 3232 2041 
+Q 3021 2317 2650 2400 
+L 2650 2413 
+Q 2963 2502 3120 2752 
+Q 3277 3002 3277 3328 
+Q 3277 3629 3142 3859 
+Q 3008 4090 2793 4250 
+Q 2579 4410 2310 4490 
+Q 2042 4570 1773 4570 
+Q 1427 4570 1145 4458 
+Q 864 4346 662 4141 
+Q 461 3936 349 3651 
+Q 237 3366 224 3021 
+L 1088 3021 
+Q 1082 3366 1258 3593 
+Q 1434 3821 1779 3821 
+Q 2029 3821 2221 3667 
+Q 2413 3514 2413 3226 
+Q 2413 3034 2320 2918 
+Q 2227 2803 2083 2742 
+Q 1939 2682 1772 2669 
+Q 1606 2656 1459 2669 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-76" d="M 2176 0 
+L 3296 3309 
+L 2394 3309 
+L 1696 1050 
+L 1683 1050 
+L 986 3309 
+L 32 3309 
+L 1165 0 
+L 2176 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-69" d="M 1280 3821 
+L 1280 4570 
+L 371 4570 
+L 371 3821 
+L 1280 3821 
+z
+M 371 3309 
+L 371 0 
+L 1280 0 
+L 1280 3309 
+L 371 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-67" d="M 1888 781 
+Q 1677 781 1536 870 
+Q 1395 960 1308 1101 
+Q 1222 1242 1187 1418 
+Q 1152 1594 1152 1773 
+Q 1152 1958 1193 2128 
+Q 1235 2298 1328 2429 
+Q 1421 2560 1558 2637 
+Q 1696 2714 1888 2714 
+Q 2112 2714 2259 2630 
+Q 2406 2547 2496 2406 
+Q 2586 2266 2624 2083 
+Q 2662 1901 2662 1696 
+Q 2662 1517 2614 1353 
+Q 2566 1190 2470 1062 
+Q 2374 934 2227 857 
+Q 2080 781 1888 781 
+z
+M 3526 211 
+L 3526 3309 
+L 2662 3309 
+L 2662 2867 
+L 2650 2867 
+Q 2483 3155 2236 3276 
+Q 1990 3398 1664 3398 
+Q 1318 3398 1052 3264 
+Q 787 3130 608 2902 
+Q 429 2675 336 2377 
+Q 243 2080 243 1760 
+Q 243 1421 323 1117 
+Q 403 813 576 585 
+Q 749 358 1017 227 
+Q 1286 96 1658 96 
+Q 1958 96 2230 221 
+Q 2502 346 2650 608 
+L 2662 608 
+L 2662 173 
+Q 2669 -179 2493 -409 
+Q 2317 -640 1933 -640 
+Q 1690 -640 1504 -541 
+Q 1318 -442 1254 -186 
+L 352 -186 
+Q 371 -467 508 -668 
+Q 646 -870 854 -998 
+Q 1062 -1126 1315 -1187 
+Q 1568 -1248 1811 -1248 
+Q 2381 -1248 2720 -1094 
+Q 3059 -941 3238 -720 
+Q 3418 -499 3472 -243 
+Q 3526 13 3526 211 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-6c" d="M 371 4570 
+L 371 0 
+L 1280 0 
+L 1280 4570 
+L 371 4570 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-d7" d="M 410 595 
+L 896 109 
+L 1926 1139 
+L 2950 109 
+L 3437 595 
+L 2406 1619 
+L 3437 2643 
+L 2950 3130 
+L 1926 2106 
+L 909 3130 
+L 422 2643 
+L 1440 1619 
+L 410 595 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-64" d="M 2694 1664 
+Q 2694 1459 2656 1267 
+Q 2618 1075 2528 924 
+Q 2438 774 2288 684 
+Q 2138 595 1914 595 
+Q 1702 595 1552 688 
+Q 1402 781 1302 931 
+Q 1203 1082 1158 1274 
+Q 1114 1466 1114 1658 
+Q 1114 1862 1155 2051 
+Q 1197 2240 1289 2387 
+Q 1382 2534 1536 2624 
+Q 1690 2714 1914 2714 
+Q 2138 2714 2285 2624 
+Q 2432 2534 2525 2390 
+Q 2618 2246 2656 2057 
+Q 2694 1869 2694 1664 
+z
+M 2707 422 
+L 2707 0 
+L 3571 0 
+L 3571 4570 
+L 2662 4570 
+L 2662 2906 
+L 2650 2906 
+Q 2496 3149 2230 3273 
+Q 1965 3398 1670 3398 
+Q 1306 3398 1030 3254 
+Q 755 3110 572 2873 
+Q 390 2637 297 2326 
+Q 205 2016 205 1683 
+Q 205 1338 297 1018 
+Q 390 698 572 451 
+Q 755 205 1036 61 
+Q 1318 -83 1690 -83 
+Q 2016 -83 2275 35 
+Q 2534 154 2694 422 
+L 2707 422 
+z
+" transform="scale(0.015625)"/>
+      <path id="HelveticaNeue-Bold-79" d="M 1978 -410 
+L 3360 3309 
+L 2419 3309 
+L 1696 1043 
+L 1683 1043 
+L 934 3309 
+L -32 3309 
+L 1126 205 
+Q 1165 109 1165 0 
+Q 1165 -147 1078 -268 
+Q 992 -390 813 -410 
+Q 678 -416 544 -403 
+Q 410 -390 282 -378 
+L 282 -1126 
+Q 422 -1139 560 -1148 
+Q 698 -1158 838 -1158 
+Q 1306 -1158 1568 -985 
+Q 1830 -813 1978 -410 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#HelveticaNeue-Bold-54"/>
+     <use xlink:href="#HelveticaNeue-Bold-68" x="61.099991"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="120.399979"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="177.799973"/>
+     <use xlink:href="#HelveticaNeue-Bold-4b" x="205.59996"/>
+     <use xlink:href="#HelveticaNeue-Bold-33" x="277.799942"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="333.399933"/>
+     <use xlink:href="#HelveticaNeue-Bold-73" x="361.199921"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="414.899918"/>
+     <use xlink:href="#HelveticaNeue-Bold-72" x="472.299911"/>
+     <use xlink:href="#HelveticaNeue-Bold-76" x="511.199905"/>
+     <use xlink:href="#HelveticaNeue-Bold-69" x="563.19989"/>
+     <use xlink:href="#HelveticaNeue-Bold-6e" x="588.999878"/>
+     <use xlink:href="#HelveticaNeue-Bold-67" x="648.299866"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="709.399857"/>
+     <use xlink:href="#HelveticaNeue-Bold-66" x="737.199844"/>
+     <use xlink:href="#HelveticaNeue-Bold-72" x="770.499832"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="807.649826"/>
+     <use xlink:href="#HelveticaNeue-Bold-6e" x="868.749817"/>
+     <use xlink:href="#HelveticaNeue-Bold-74" x="928.049805"/>
+     <use xlink:href="#HelveticaNeue-Bold-69" x="963.249802"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="989.049789"/>
+     <use xlink:href="#HelveticaNeue-Bold-72" x="1046.449783"/>
+     <use xlink:href="#HelveticaNeue-Bold-3a" x="1085.349777"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1113.149765"/>
+     <use xlink:href="#HelveticaNeue-Bold-70" x="1140.949753"/>
+     <use xlink:href="#HelveticaNeue-Bold-72" x="1202.049744"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="1239.199738"/>
+     <use xlink:href="#HelveticaNeue-Bold-66" x="1296.599731"/>
+     <use xlink:href="#HelveticaNeue-Bold-69" x="1329.899719"/>
+     <use xlink:href="#HelveticaNeue-Bold-6c" x="1355.699707"/>
+     <use xlink:href="#HelveticaNeue-Bold-6c" x="1381.499695"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1407.299683"/>
+     <use xlink:href="#HelveticaNeue-Bold-d7" x="1435.09967"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1495.099655"/>
+     <use xlink:href="#HelveticaNeue-Bold-64" x="1522.899643"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="1583.999634"/>
+     <use xlink:href="#HelveticaNeue-Bold-63" x="1641.399628"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="1698.799622"/>
+     <use xlink:href="#HelveticaNeue-Bold-64" x="1759.899612"/>
+     <use xlink:href="#HelveticaNeue-Bold-65" x="1820.999603"/>
+     <use xlink:href="#HelveticaNeue-Bold-20" x="1878.399597"/>
+     <use xlink:href="#HelveticaNeue-Bold-74" x="1906.199585"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="1941.399582"/>
+     <use xlink:href="#HelveticaNeue-Bold-70" x="2002.499573"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="2063.599564"/>
+     <use xlink:href="#HelveticaNeue-Bold-6c" x="2124.699554"/>
+     <use xlink:href="#HelveticaNeue-Bold-6f" x="2150.499542"/>
+     <use xlink:href="#HelveticaNeue-Bold-67" x="2211.599533"/>
+     <use xlink:href="#HelveticaNeue-Bold-79" x="2272.699524"/>
     </g>
    </g>
    <g id="legend_1">
-    <g id="line2d_89">
+    <g id="line2d_54">
      <g>
-      <use xlink:href="#mce57ce64a3" x="660.1232" y="62.7815" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
+      <use xlink:href="#md7a466de16" x="857.9892" y="51.596562" style="fill: #2a6fb5; stroke: #fcfcfb; stroke-width: 1.4"/>
      </g>
     </g>
-    <g id="text_22">
-     <!-- PP8 $\to$ TP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 66.1065) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(363.55368 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(420.953629 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(485.753571 0.59375)"/>
+    <g id="text_26">
+     <!-- PP8 → TP8 · 1P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 54.921562) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-54" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-50" x="381.988998"/>
+      <use xlink:href="#HelveticaNeue-38" x="446.788986"/>
+      <use xlink:href="#HelveticaNeue-20" x="502.388977"/>
+      <use xlink:href="#HelveticaNeue-b7" x="530.188965"/>
+      <use xlink:href="#HelveticaNeue-20" x="557.988953"/>
+      <use xlink:href="#HelveticaNeue-31" x="585.78894"/>
+      <use xlink:href="#HelveticaNeue-50" x="641.388931"/>
+      <use xlink:href="#HelveticaNeue-3a" x="706.188919"/>
+      <use xlink:href="#HelveticaNeue-31" x="733.988907"/>
+      <use xlink:href="#HelveticaNeue-44" x="789.588898"/>
      </g>
     </g>
-    <g id="line2d_90">
+    <g id="line2d_55">
      <g>
-      <use xlink:href="#mabcc5902ca" x="660.1232" y="79.074" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m781f438463" x="857.9892" y="67.091953" style="fill: #3d9457; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_23">
-     <!-- PP8 $\to$ DCP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 82.399) scale(0.095 -0.095)">
+    <g id="text_27">
+     <!-- PP8 → DCP8 · 1P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 70.416953) scale(0.095 -0.095)">
       <defs>
-       <path id="HelveticaNeue-2a" d="M 3712 3194 
+       <path id="HelveticaNeue-43" d="M 3712 3194 
 L 4320 3194 
 Q 4269 3558 4102 3836 
 Q 3936 4115 3686 4300 
@@ -3526,73 +3432,97 @@ Q 3610 3680 3712 3194
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.90625)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2b" transform="translate(363.55368 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2a" transform="translate(433.953613 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(506.153549 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(570.953491 0.90625)"/>
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-44" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-43" x="394.988998"/>
+      <use xlink:href="#HelveticaNeue-50" x="467.18898"/>
+      <use xlink:href="#HelveticaNeue-38" x="531.988968"/>
+      <use xlink:href="#HelveticaNeue-20" x="587.588959"/>
+      <use xlink:href="#HelveticaNeue-b7" x="615.388947"/>
+      <use xlink:href="#HelveticaNeue-20" x="643.188934"/>
+      <use xlink:href="#HelveticaNeue-31" x="670.988922"/>
+      <use xlink:href="#HelveticaNeue-50" x="726.588913"/>
+      <use xlink:href="#HelveticaNeue-3a" x="791.388901"/>
+      <use xlink:href="#HelveticaNeue-31" x="819.188889"/>
+      <use xlink:href="#HelveticaNeue-44" x="874.788879"/>
      </g>
     </g>
-    <g id="line2d_91">
+    <g id="line2d_56">
      <g>
-      <use xlink:href="#m6c29795d04" x="660.1232" y="95.3665" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m1a2249dbbc" x="857.9892" y="82.587344" style="fill: #4e8fcb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_24">
-     <!-- PP8 $\to$ 2×TP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 98.6915) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-19" transform="translate(363.55368 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(419.153625 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(479.153564 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(536.553513 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(601.353455 0.59375)"/>
+    <g id="text_28">
+     <!-- PP8 → 2×TP8 · 1P:2D -->
+     <g style="fill: #52514e" transform="translate(874.1392 85.912344) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-32" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-d7" x="380.188995"/>
+      <use xlink:href="#HelveticaNeue-54" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-50" x="497.588974"/>
+      <use xlink:href="#HelveticaNeue-38" x="562.388962"/>
+      <use xlink:href="#HelveticaNeue-20" x="617.988953"/>
+      <use xlink:href="#HelveticaNeue-b7" x="645.78894"/>
+      <use xlink:href="#HelveticaNeue-20" x="673.588928"/>
+      <use xlink:href="#HelveticaNeue-31" x="701.388916"/>
+      <use xlink:href="#HelveticaNeue-50" x="756.988907"/>
+      <use xlink:href="#HelveticaNeue-3a" x="821.788895"/>
+      <use xlink:href="#HelveticaNeue-32" x="849.588882"/>
+      <use xlink:href="#HelveticaNeue-44" x="905.188873"/>
      </g>
     </g>
-    <g id="line2d_92">
+    <g id="line2d_57">
      <g>
-      <use xlink:href="#m655a7782e0" x="660.1232" y="111.659" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m38faf0c88f" x="857.9892" y="98.082734" style="fill: #7fbb8f; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_25">
-     <!-- 2×PP8 $\to$ 2×DCP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 114.984) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-19" transform="translate(0 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(55.599945 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(115.599884 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(180.399826 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(245.199768 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(300.799713 0.90625)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(348.082108 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(451.353592 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-19" transform="translate(479.153564 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(534.75351 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2b" transform="translate(594.753448 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2a" transform="translate(665.153381 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(737.353317 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(802.153259 0.90625)"/>
+    <g id="text_29">
+     <!-- 2×PP8 → 2×DCP8 · 2P:2D -->
+     <g style="fill: #52514e" transform="translate(874.1392 101.407734) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-32"/>
+      <use xlink:href="#HelveticaNeue-d7" x="55.599991"/>
+      <use xlink:href="#HelveticaNeue-50" x="115.599976"/>
+      <use xlink:href="#HelveticaNeue-50" x="180.399963"/>
+      <use xlink:href="#HelveticaNeue-38" x="245.199951"/>
+      <use xlink:href="#HelveticaNeue-20" x="300.799942"/>
+      <use xlink:href="#DejaVuSans-2192" x="328.59993"/>
+      <use xlink:href="#HelveticaNeue-20" x="412.388992"/>
+      <use xlink:href="#HelveticaNeue-32" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-d7" x="495.788971"/>
+      <use xlink:href="#HelveticaNeue-44" x="555.788956"/>
+      <use xlink:href="#HelveticaNeue-43" x="626.18895"/>
+      <use xlink:href="#HelveticaNeue-50" x="698.388931"/>
+      <use xlink:href="#HelveticaNeue-38" x="763.188919"/>
+      <use xlink:href="#HelveticaNeue-20" x="818.78891"/>
+      <use xlink:href="#HelveticaNeue-b7" x="846.588898"/>
+      <use xlink:href="#HelveticaNeue-20" x="874.388885"/>
+      <use xlink:href="#HelveticaNeue-32" x="902.188873"/>
+      <use xlink:href="#HelveticaNeue-50" x="957.788864"/>
+      <use xlink:href="#HelveticaNeue-3a" x="1022.588852"/>
+      <use xlink:href="#HelveticaNeue-32" x="1050.38884"/>
+      <use xlink:href="#HelveticaNeue-44" x="1105.988831"/>
      </g>
     </g>
-    <g id="line2d_93">
+    <g id="line2d_58">
      <g>
-      <use xlink:href="#m1080350280" x="660.1232" y="127.9515" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m3577f524eb" x="857.9892" y="113.738438" style="fill: #c98d85; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_26">
-     <!-- 2×PP8 $\to$ DCP8 dp4 EP32 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 131.2765) scale(0.095 -0.095)">
+    <g id="text_30">
+     <!-- 2×PP8 → DCP8 dp4 EP32 · 2P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 117.063438) scale(0.095 -0.095)">
       <defs>
-       <path id="HelveticaNeue-2c" d="M 499 4570 
+       <path id="HelveticaNeue-45" d="M 499 4570 
 L 499 0 
 L 3674 0 
 L 3674 512 
@@ -3608,112 +3538,144 @@ L 499 4570
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#HelveticaNeue-19" transform="translate(0 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(55.599945 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(115.599884 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(180.399826 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(245.199768 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(300.799713 0.90625)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(348.082108 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(451.353592 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2b" transform="translate(479.153564 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2a" transform="translate(549.553497 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(621.753433 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(686.553375 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(742.15332 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-4b" transform="translate(769.953293 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(829.253235 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1b" transform="translate(888.553177 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(944.153122 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2c" transform="translate(971.953094 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(1033.05304 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1a" transform="translate(1097.852982 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-19" transform="translate(1153.452927 0.90625)"/>
+      <use xlink:href="#HelveticaNeue-32"/>
+      <use xlink:href="#HelveticaNeue-d7" x="55.599991"/>
+      <use xlink:href="#HelveticaNeue-50" x="115.599976"/>
+      <use xlink:href="#HelveticaNeue-50" x="180.399963"/>
+      <use xlink:href="#HelveticaNeue-38" x="245.199951"/>
+      <use xlink:href="#HelveticaNeue-20" x="300.799942"/>
+      <use xlink:href="#DejaVuSans-2192" x="328.59993"/>
+      <use xlink:href="#HelveticaNeue-20" x="412.388992"/>
+      <use xlink:href="#HelveticaNeue-44" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-43" x="510.588974"/>
+      <use xlink:href="#HelveticaNeue-50" x="582.788956"/>
+      <use xlink:href="#HelveticaNeue-38" x="647.588943"/>
+      <use xlink:href="#HelveticaNeue-20" x="703.188934"/>
+      <use xlink:href="#HelveticaNeue-64" x="730.988922"/>
+      <use xlink:href="#HelveticaNeue-70" x="790.28891"/>
+      <use xlink:href="#HelveticaNeue-34" x="849.588898"/>
+      <use xlink:href="#HelveticaNeue-20" x="905.188889"/>
+      <use xlink:href="#HelveticaNeue-45" x="932.988876"/>
+      <use xlink:href="#HelveticaNeue-50" x="994.088867"/>
+      <use xlink:href="#HelveticaNeue-33" x="1058.888855"/>
+      <use xlink:href="#HelveticaNeue-32" x="1114.488846"/>
+      <use xlink:href="#HelveticaNeue-20" x="1170.088837"/>
+      <use xlink:href="#HelveticaNeue-b7" x="1197.888824"/>
+      <use xlink:href="#HelveticaNeue-20" x="1225.688812"/>
+      <use xlink:href="#HelveticaNeue-32" x="1253.4888"/>
+      <use xlink:href="#HelveticaNeue-50" x="1309.088791"/>
+      <use xlink:href="#HelveticaNeue-3a" x="1373.888779"/>
+      <use xlink:href="#HelveticaNeue-31" x="1401.688766"/>
+      <use xlink:href="#HelveticaNeue-44" x="1457.288757"/>
      </g>
     </g>
-    <g id="line2d_94">
+    <g id="line2d_59">
      <g>
-      <use xlink:href="#m3038e22dff" x="660.1232" y="144.244" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m73dcf444f8" x="857.9892" y="129.394141" style="fill: #a3584e; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_27">
-     <!-- 2×PP8 $\to$ DCP8 dp2 EP16 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 147.569) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-19" transform="translate(0 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(55.599945 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(115.599884 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(180.399826 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(245.199768 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(300.799713 0.90625)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(348.082108 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(451.353592 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2b" transform="translate(479.153564 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2a" transform="translate(549.553497 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(621.753433 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(686.553375 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(742.15332 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-4b" transform="translate(769.953293 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-57" transform="translate(829.253235 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-19" transform="translate(888.553177 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(944.153122 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2c" transform="translate(971.953094 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(1033.05304 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-18" transform="translate(1097.852982 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1d" transform="translate(1153.452927 0.90625)"/>
+    <g id="text_31">
+     <!-- 2×PP8 → DCP8 dp2 EP16 · 2P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 132.719141) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-32"/>
+      <use xlink:href="#HelveticaNeue-d7" x="55.599991"/>
+      <use xlink:href="#HelveticaNeue-50" x="115.599976"/>
+      <use xlink:href="#HelveticaNeue-50" x="180.399963"/>
+      <use xlink:href="#HelveticaNeue-38" x="245.199951"/>
+      <use xlink:href="#HelveticaNeue-20" x="300.799942"/>
+      <use xlink:href="#DejaVuSans-2192" x="328.59993"/>
+      <use xlink:href="#HelveticaNeue-20" x="412.388992"/>
+      <use xlink:href="#HelveticaNeue-44" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-43" x="510.588974"/>
+      <use xlink:href="#HelveticaNeue-50" x="582.788956"/>
+      <use xlink:href="#HelveticaNeue-38" x="647.588943"/>
+      <use xlink:href="#HelveticaNeue-20" x="703.188934"/>
+      <use xlink:href="#HelveticaNeue-64" x="730.988922"/>
+      <use xlink:href="#HelveticaNeue-70" x="790.28891"/>
+      <use xlink:href="#HelveticaNeue-32" x="849.588898"/>
+      <use xlink:href="#HelveticaNeue-20" x="905.188889"/>
+      <use xlink:href="#HelveticaNeue-45" x="932.988876"/>
+      <use xlink:href="#HelveticaNeue-50" x="994.088867"/>
+      <use xlink:href="#HelveticaNeue-31" x="1058.888855"/>
+      <use xlink:href="#HelveticaNeue-36" x="1114.488846"/>
+      <use xlink:href="#HelveticaNeue-20" x="1170.088837"/>
+      <use xlink:href="#HelveticaNeue-b7" x="1197.888824"/>
+      <use xlink:href="#HelveticaNeue-20" x="1225.688812"/>
+      <use xlink:href="#HelveticaNeue-32" x="1253.4888"/>
+      <use xlink:href="#HelveticaNeue-50" x="1309.088791"/>
+      <use xlink:href="#HelveticaNeue-3a" x="1373.888779"/>
+      <use xlink:href="#HelveticaNeue-31" x="1401.688766"/>
+      <use xlink:href="#HelveticaNeue-44" x="1457.288757"/>
      </g>
     </g>
-    <g id="line2d_95">
+    <g id="line2d_60">
      <g>
-      <use xlink:href="#m6c1b33c3de" x="660.1232" y="160.5365" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m1886d6ca30" x="857.9892" y="144.889531" style="fill: #79aedb; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_28">
-     <!-- PP8 $\to$ 3×TP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 163.8615) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1a" transform="translate(363.55368 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(419.153625 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(479.153564 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(536.553513 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(601.353455 0.59375)"/>
+    <g id="text_32">
+     <!-- PP8 → 3×TP8 · 1P:3D -->
+     <g style="fill: #52514e" transform="translate(874.1392 148.214531) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-33" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-d7" x="380.188995"/>
+      <use xlink:href="#HelveticaNeue-54" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-50" x="497.588974"/>
+      <use xlink:href="#HelveticaNeue-38" x="562.388962"/>
+      <use xlink:href="#HelveticaNeue-20" x="617.988953"/>
+      <use xlink:href="#HelveticaNeue-b7" x="645.78894"/>
+      <use xlink:href="#HelveticaNeue-20" x="673.588928"/>
+      <use xlink:href="#HelveticaNeue-31" x="701.388916"/>
+      <use xlink:href="#HelveticaNeue-50" x="756.988907"/>
+      <use xlink:href="#HelveticaNeue-3a" x="821.788895"/>
+      <use xlink:href="#HelveticaNeue-33" x="849.588882"/>
+      <use xlink:href="#HelveticaNeue-44" x="905.188873"/>
      </g>
     </g>
-    <g id="line2d_96">
+    <g id="line2d_61">
      <g>
-      <use xlink:href="#m51497f9b2e" x="660.1232" y="176.829" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#m7d7510e2da" x="857.9892" y="160.384922" style="fill: #a5cbe8; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_29">
-     <!-- PP8 $\to$ 4×TP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 180.154) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1b" transform="translate(363.55368 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-ed" transform="translate(419.153625 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(479.153564 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(536.553513 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(601.353455 0.59375)"/>
+    <g id="text_33">
+     <!-- PP8 → 4×TP8 · 1P:4D -->
+     <g style="fill: #52514e" transform="translate(874.1392 163.709922) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-34" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-d7" x="380.188995"/>
+      <use xlink:href="#HelveticaNeue-54" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-50" x="497.588974"/>
+      <use xlink:href="#HelveticaNeue-38" x="562.388962"/>
+      <use xlink:href="#HelveticaNeue-20" x="617.988953"/>
+      <use xlink:href="#HelveticaNeue-b7" x="645.78894"/>
+      <use xlink:href="#HelveticaNeue-20" x="673.588928"/>
+      <use xlink:href="#HelveticaNeue-31" x="701.388916"/>
+      <use xlink:href="#HelveticaNeue-50" x="756.988907"/>
+      <use xlink:href="#HelveticaNeue-3a" x="821.788895"/>
+      <use xlink:href="#HelveticaNeue-34" x="849.588882"/>
+      <use xlink:href="#HelveticaNeue-44" x="905.188873"/>
      </g>
     </g>
-    <g id="line2d_97">
+    <g id="line2d_62">
      <g>
-      <use xlink:href="#m278e68defa" x="660.1232" y="193.1215" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+      <use xlink:href="#mb6816ce147" x="857.9892" y="175.880313" style="fill: #b9713c; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_30">
-     <!-- PP8 $\to$ TP8+EP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 196.4465) scale(0.095 -0.095)">
+    <g id="text_34">
+     <!-- PP8 → TP8+EP8 · 1P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 179.205312) scale(0.095 -0.095)">
       <defs>
-       <path id="HelveticaNeue-12" d="M 2138 1837 
+       <path id="HelveticaNeue-2b" d="M 2138 1837 
 L 2138 3238 
 L 1702 3238 
 L 1702 1837 
@@ -3729,149 +3691,534 @@ L 2138 1837
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.59375)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-3b" transform="translate(363.55368 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(420.953629 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(485.753571 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-12" transform="translate(541.353516 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-2c" transform="translate(601.353455 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(662.4534 0.59375)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(727.253342 0.59375)"/>
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-54" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-50" x="381.988998"/>
+      <use xlink:href="#HelveticaNeue-38" x="446.788986"/>
+      <use xlink:href="#HelveticaNeue-2b" x="502.388977"/>
+      <use xlink:href="#HelveticaNeue-45" x="562.388962"/>
+      <use xlink:href="#HelveticaNeue-50" x="623.488953"/>
+      <use xlink:href="#HelveticaNeue-38" x="688.28894"/>
+      <use xlink:href="#HelveticaNeue-20" x="743.888931"/>
+      <use xlink:href="#HelveticaNeue-b7" x="771.688919"/>
+      <use xlink:href="#HelveticaNeue-20" x="799.488907"/>
+      <use xlink:href="#HelveticaNeue-31" x="827.288895"/>
+      <use xlink:href="#HelveticaNeue-50" x="882.888885"/>
+      <use xlink:href="#HelveticaNeue-3a" x="947.688873"/>
+      <use xlink:href="#HelveticaNeue-31" x="975.488861"/>
+      <use xlink:href="#HelveticaNeue-44" x="1031.088852"/>
      </g>
     </g>
-    <g id="line2d_98">
+    <g id="line2d_63">
      <g>
-      <use xlink:href="#md659ae9f1e" x="660.1232" y="209.414" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
+      <use xlink:href="#m4eb6b22513" x="857.9892" y="191.375703" style="fill: #d99b12; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: bevel"/>
      </g>
     </g>
-    <g id="text_31">
-     <!-- PP8 $\to$ DCP8+EP8 -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 212.739) scale(0.095 -0.095)">
-      <use xlink:href="#HelveticaNeue-37" transform="translate(0 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(64.799942 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(129.599884 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(185.199829 0.90625)"/>
-      <use xlink:href="#DejaVuSans-c1c" transform="translate(232.482224 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(335.753708 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2b" transform="translate(363.55368 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2a" transform="translate(433.953613 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(506.153549 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(570.953491 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-12" transform="translate(626.553436 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-2c" transform="translate(686.553375 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-37" transform="translate(747.65332 0.90625)"/>
-      <use xlink:href="#HelveticaNeue-1f" transform="translate(812.453262 0.90625)"/>
+    <g id="text_35">
+     <!-- PP8 → DCP8+EP8 · 1P:1D -->
+     <g style="fill: #52514e" transform="translate(874.1392 194.700703) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-44" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-43" x="394.988998"/>
+      <use xlink:href="#HelveticaNeue-50" x="467.18898"/>
+      <use xlink:href="#HelveticaNeue-38" x="531.988968"/>
+      <use xlink:href="#HelveticaNeue-2b" x="587.588959"/>
+      <use xlink:href="#HelveticaNeue-45" x="647.588943"/>
+      <use xlink:href="#HelveticaNeue-50" x="708.688934"/>
+      <use xlink:href="#HelveticaNeue-38" x="773.488922"/>
+      <use xlink:href="#HelveticaNeue-20" x="829.088913"/>
+      <use xlink:href="#HelveticaNeue-b7" x="856.888901"/>
+      <use xlink:href="#HelveticaNeue-20" x="884.688889"/>
+      <use xlink:href="#HelveticaNeue-31" x="912.488876"/>
+      <use xlink:href="#HelveticaNeue-50" x="968.088867"/>
+      <use xlink:href="#HelveticaNeue-3a" x="1032.888855"/>
+      <use xlink:href="#HelveticaNeue-31" x="1060.688843"/>
+      <use xlink:href="#HelveticaNeue-44" x="1116.288834"/>
      </g>
     </g>
-    <g id="line2d_99">
-     <path d="M 654.4232 225.7065 
-L 660.1232 225.7065 
-L 665.8232 225.7065 
-" style="fill: none; stroke: #1a1b1d; stroke-width: 2.6; stroke-linecap: square"/>
+    <g id="line2d_64">
+     <g>
+      <use xlink:href="#m2846000dfd" x="857.9892" y="206.946797" style="fill: #0f7b72; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     </g>
     </g>
-    <g id="text_32">
+    <g id="text_36">
+     <!-- PP8 → TP8 · 1P:1D · fp4 -->
+     <g style="fill: #52514e" transform="translate(874.1392 210.271797) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-54" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-50" x="381.988998"/>
+      <use xlink:href="#HelveticaNeue-38" x="446.788986"/>
+      <use xlink:href="#HelveticaNeue-20" x="502.388977"/>
+      <use xlink:href="#HelveticaNeue-b7" x="530.188965"/>
+      <use xlink:href="#HelveticaNeue-20" x="557.988953"/>
+      <use xlink:href="#HelveticaNeue-31" x="585.78894"/>
+      <use xlink:href="#HelveticaNeue-50" x="641.388931"/>
+      <use xlink:href="#HelveticaNeue-3a" x="706.188919"/>
+      <use xlink:href="#HelveticaNeue-31" x="733.988907"/>
+      <use xlink:href="#HelveticaNeue-44" x="789.588898"/>
+      <use xlink:href="#HelveticaNeue-20" x="859.988892"/>
+      <use xlink:href="#HelveticaNeue-b7" x="887.788879"/>
+      <use xlink:href="#HelveticaNeue-20" x="915.588867"/>
+      <use xlink:href="#HelveticaNeue-66" x="943.388855"/>
+      <use xlink:href="#HelveticaNeue-70" x="972.988846"/>
+      <use xlink:href="#HelveticaNeue-34" x="1032.288834"/>
+     </g>
+    </g>
+    <g id="line2d_65">
+     <g>
+      <use xlink:href="#m6504e2d535" x="857.9892" y="222.517891" style="fill: #5cb3aa; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_37">
+     <!-- PP8 → 3×TP8 · 1P:3D · fp4 -->
+     <g style="fill: #52514e" transform="translate(874.1392 225.842891) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-50" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-38" x="129.599976"/>
+      <use xlink:href="#HelveticaNeue-20" x="185.199966"/>
+      <use xlink:href="#DejaVuSans-2192" x="212.999954"/>
+      <use xlink:href="#HelveticaNeue-20" x="296.789017"/>
+      <use xlink:href="#HelveticaNeue-33" x="324.589005"/>
+      <use xlink:href="#HelveticaNeue-d7" x="380.188995"/>
+      <use xlink:href="#HelveticaNeue-54" x="440.18898"/>
+      <use xlink:href="#HelveticaNeue-50" x="497.588974"/>
+      <use xlink:href="#HelveticaNeue-38" x="562.388962"/>
+      <use xlink:href="#HelveticaNeue-20" x="617.988953"/>
+      <use xlink:href="#HelveticaNeue-b7" x="645.78894"/>
+      <use xlink:href="#HelveticaNeue-20" x="673.588928"/>
+      <use xlink:href="#HelveticaNeue-31" x="701.388916"/>
+      <use xlink:href="#HelveticaNeue-50" x="756.988907"/>
+      <use xlink:href="#HelveticaNeue-3a" x="821.788895"/>
+      <use xlink:href="#HelveticaNeue-33" x="849.588882"/>
+      <use xlink:href="#HelveticaNeue-44" x="905.188873"/>
+      <use xlink:href="#HelveticaNeue-20" x="975.588867"/>
+      <use xlink:href="#HelveticaNeue-b7" x="1003.388855"/>
+      <use xlink:href="#HelveticaNeue-20" x="1031.188843"/>
+      <use xlink:href="#HelveticaNeue-66" x="1058.988831"/>
+      <use xlink:href="#HelveticaNeue-70" x="1088.588821"/>
+      <use xlink:href="#HelveticaNeue-34" x="1147.888809"/>
+     </g>
+    </g>
+    <g id="line2d_66">
+     <g>
+      <use xlink:href="#m54cb7b72e9" x="857.9892" y="238.088984" style="fill: #7d5ba6; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_38">
+     <!-- TP8 → 2×TP8 · 1P:2D · fp4 -->
+     <g style="fill: #52514e" transform="translate(874.1392 241.413984) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-54"/>
+      <use xlink:href="#HelveticaNeue-50" x="57.399994"/>
+      <use xlink:href="#HelveticaNeue-38" x="122.199982"/>
+      <use xlink:href="#HelveticaNeue-20" x="177.799973"/>
+      <use xlink:href="#DejaVuSans-2192" x="205.59996"/>
+      <use xlink:href="#HelveticaNeue-20" x="289.389023"/>
+      <use xlink:href="#HelveticaNeue-32" x="317.189011"/>
+      <use xlink:href="#HelveticaNeue-d7" x="372.789001"/>
+      <use xlink:href="#HelveticaNeue-54" x="432.788986"/>
+      <use xlink:href="#HelveticaNeue-50" x="490.18898"/>
+      <use xlink:href="#HelveticaNeue-38" x="554.988968"/>
+      <use xlink:href="#HelveticaNeue-20" x="610.588959"/>
+      <use xlink:href="#HelveticaNeue-b7" x="638.388947"/>
+      <use xlink:href="#HelveticaNeue-20" x="666.188934"/>
+      <use xlink:href="#HelveticaNeue-31" x="693.988922"/>
+      <use xlink:href="#HelveticaNeue-50" x="749.588913"/>
+      <use xlink:href="#HelveticaNeue-3a" x="814.388901"/>
+      <use xlink:href="#HelveticaNeue-32" x="842.188889"/>
+      <use xlink:href="#HelveticaNeue-44" x="897.788879"/>
+      <use xlink:href="#HelveticaNeue-20" x="968.188873"/>
+      <use xlink:href="#HelveticaNeue-b7" x="995.988861"/>
+      <use xlink:href="#HelveticaNeue-20" x="1023.788849"/>
+      <use xlink:href="#HelveticaNeue-66" x="1051.588837"/>
+      <use xlink:href="#HelveticaNeue-70" x="1081.188828"/>
+      <use xlink:href="#HelveticaNeue-34" x="1140.488815"/>
+     </g>
+    </g>
+    <g id="line2d_67">
+     <g>
+      <use xlink:href="#mfb8fc8c0f1" x="857.9892" y="253.660078" style="fill: #b49ad1; stroke: #fcfcfb; stroke-width: 1.4; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_39">
+     <!-- TP8 → 3×TP8 · 1P:3D · fp4 -->
+     <g style="fill: #52514e" transform="translate(874.1392 256.985078) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-54"/>
+      <use xlink:href="#HelveticaNeue-50" x="57.399994"/>
+      <use xlink:href="#HelveticaNeue-38" x="122.199982"/>
+      <use xlink:href="#HelveticaNeue-20" x="177.799973"/>
+      <use xlink:href="#DejaVuSans-2192" x="205.59996"/>
+      <use xlink:href="#HelveticaNeue-20" x="289.389023"/>
+      <use xlink:href="#HelveticaNeue-33" x="317.189011"/>
+      <use xlink:href="#HelveticaNeue-d7" x="372.789001"/>
+      <use xlink:href="#HelveticaNeue-54" x="432.788986"/>
+      <use xlink:href="#HelveticaNeue-50" x="490.18898"/>
+      <use xlink:href="#HelveticaNeue-38" x="554.988968"/>
+      <use xlink:href="#HelveticaNeue-20" x="610.588959"/>
+      <use xlink:href="#HelveticaNeue-b7" x="638.388947"/>
+      <use xlink:href="#HelveticaNeue-20" x="666.188934"/>
+      <use xlink:href="#HelveticaNeue-31" x="693.988922"/>
+      <use xlink:href="#HelveticaNeue-50" x="749.588913"/>
+      <use xlink:href="#HelveticaNeue-3a" x="814.388901"/>
+      <use xlink:href="#HelveticaNeue-33" x="842.188889"/>
+      <use xlink:href="#HelveticaNeue-44" x="897.788879"/>
+      <use xlink:href="#HelveticaNeue-20" x="968.188873"/>
+      <use xlink:href="#HelveticaNeue-b7" x="995.988861"/>
+      <use xlink:href="#HelveticaNeue-20" x="1023.788849"/>
+      <use xlink:href="#HelveticaNeue-66" x="1051.588837"/>
+      <use xlink:href="#HelveticaNeue-70" x="1081.188828"/>
+      <use xlink:href="#HelveticaNeue-34" x="1140.488815"/>
+     </g>
+    </g>
+    <g id="line2d_68">
+     <path d="M 848.4892 269.155469 
+L 857.9892 269.155469 
+L 867.4892 269.155469 
+" style="fill: none; stroke: #1a1b1d; stroke-width: 2.6; stroke-linecap: round"/>
+    </g>
+    <g id="text_40">
      <!-- Pareto frontier -->
-     <g style="fill: #1a1b1d" transform="translate(673.4232 229.0315) scale(0.095 -0.095)">
-      <defs>
-       <path id="HelveticaNeue-4d" d="M 634 2829 
-L 634 0 
-L 1178 0 
-L 1178 2829 
-L 1818 2829 
-L 1818 3309 
-L 1178 3309 
-L 1178 3770 
-Q 1178 3987 1286 4064 
-Q 1395 4141 1594 4141 
-Q 1664 4141 1747 4131 
-Q 1830 4122 1901 4096 
-L 1901 4570 
-Q 1824 4595 1725 4608 
-Q 1626 4621 1549 4621 
-Q 1101 4621 867 4413 
-Q 634 4205 634 3802 
-L 634 3309 
-L 77 3309 
-L 77 2829 
-L 634 2829 
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#HelveticaNeue-37"/>
-      <use xlink:href="#HelveticaNeue-48" transform="translate(64.796875 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(118.5 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(150 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(203.703125 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(235.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-3" transform="translate(292.609375 0)"/>
-      <use xlink:href="#HelveticaNeue-4d" transform="translate(320.40625 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(350 0)"/>
-      <use xlink:href="#HelveticaNeue-56" transform="translate(381.5 0)"/>
-      <use xlink:href="#HelveticaNeue-55" transform="translate(438.90625 0)"/>
-      <use xlink:href="#HelveticaNeue-5b" transform="translate(494.5 0)"/>
-      <use xlink:href="#HelveticaNeue-50" transform="translate(526 0)"/>
-      <use xlink:href="#HelveticaNeue-4c" transform="translate(548.203125 0)"/>
-      <use xlink:href="#HelveticaNeue-59" transform="translate(601.90625 0)"/>
+     <g style="fill: #52514e" transform="translate(874.1392 272.480469) scale(0.095 -0.095)">
+      <use xlink:href="#HelveticaNeue-50"/>
+      <use xlink:href="#HelveticaNeue-61" x="64.799988"/>
+      <use xlink:href="#HelveticaNeue-72" x="118.499985"/>
+      <use xlink:href="#HelveticaNeue-65" x="150.049973"/>
+      <use xlink:href="#HelveticaNeue-74" x="203.749969"/>
+      <use xlink:href="#HelveticaNeue-6f" x="235.249954"/>
+      <use xlink:href="#HelveticaNeue-20" x="292.649948"/>
+      <use xlink:href="#HelveticaNeue-66" x="320.449936"/>
+      <use xlink:href="#HelveticaNeue-72" x="350.049927"/>
+      <use xlink:href="#HelveticaNeue-6f" x="381.599915"/>
+      <use xlink:href="#HelveticaNeue-6e" x="438.999908"/>
+      <use xlink:href="#HelveticaNeue-74" x="494.599899"/>
+      <use xlink:href="#HelveticaNeue-69" x="526.099884"/>
+      <use xlink:href="#HelveticaNeue-65" x="548.299881"/>
+      <use xlink:href="#HelveticaNeue-72" x="601.999878"/>
      </g>
     </g>
    </g>
   </g>
-  <g id="text_33">
-   <!-- Raw points from p0-performance E17 (3de33af8c, lyris cluster). The post-optimisation re-run reproduces the peak within noise (2,738 vs 2,715 tok/s/GPU); wide-EP decode arms are cluster-specific there. -->
-   <g style="fill: #6d716c" transform="translate(7.2 465.2835) scale(0.095 -0.095)">
+  <g id="text_41">
+   <!-- Every point is a measured GB300 run at 8K in / 1K out; repeated identical runs vary by 0.5–1%, so arms within ~2% of one another are indistinguishable. The fp4 arms come from a separate sweep. -->
+   <g style="fill: #6d716c" transform="translate(4.32 433.182675) scale(0.095 -0.095)">
     <defs>
-     <path id="HelveticaNeue-Italic-39" d="M 1011 4570 
+     <path id="HelveticaNeue-Italic-45" d="M 1011 4570 
 L 45 0 
-L 653 0 
-L 1062 1952 
-L 2413 1952 
-L 2656 1952 
-Q 2758 1946 2860 1907 
-Q 2963 1869 3033 1766 
-Q 3104 1664 3126 1475 
-Q 3149 1286 3098 979 
-Q 3027 627 3033 377 
-Q 3040 128 3085 0 
-L 3718 0 
-Q 3648 134 3635 275 
-Q 3622 416 3635 566 
-Q 3648 717 3673 867 
-Q 3699 1018 3712 1171 
-Q 3731 1344 3715 1504 
-Q 3699 1664 3644 1795 
-Q 3590 1926 3491 2022 
-Q 3392 2118 3245 2163 
-L 3245 2176 
-Q 3475 2208 3664 2317 
-Q 3853 2426 3987 2592 
-Q 4122 2758 4198 2966 
-Q 4275 3174 4275 3405 
-Q 4275 3744 4150 3968 
-Q 4026 4192 3814 4326 
-Q 3603 4461 3331 4515 
-Q 3059 4570 2771 4570 
+L 3226 0 
+L 3341 512 
+L 768 512 
+L 1101 2093 
+L 3475 2093 
+L 3578 2605 
+L 1210 2605 
+L 1517 4058 
+L 4058 4058 
+L 4160 4570 
 L 1011 4570 
 z
-M 1171 2464 
-L 1510 4058 
-L 2771 4058 
-Q 2944 4058 3104 4029 
-Q 3264 4000 3389 3923 
-Q 3514 3846 3590 3712 
-Q 3667 3578 3667 3366 
-Q 3667 3245 3625 3088 
-Q 3584 2931 3462 2793 
-Q 3341 2656 3120 2560 
-Q 2899 2464 2541 2464 
-L 1171 2464 
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-76" d="M 1325 0 
+L 3162 3309 
+L 2573 3309 
+L 1139 557 
+L 1126 557 
+L 845 3309 
+L 269 3309 
+L 742 0 
+L 1325 0 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-48" d="M 339 2310 
+     <path id="HelveticaNeue-Italic-65" d="M 627 1491 
+L 3117 1491 
+Q 3130 1562 3149 1677 
+Q 3168 1792 3168 1920 
+Q 3168 2618 2832 3002 
+Q 2496 3386 1766 3386 
+Q 1427 3386 1116 3232 
+Q 806 3078 572 2796 
+Q 339 2515 201 2121 
+Q 64 1728 64 1254 
+Q 64 1037 128 803 
+Q 192 570 352 374 
+Q 512 179 784 54 
+Q 1056 -70 1466 -70 
+Q 1734 -70 1977 0 
+Q 2221 70 2419 208 
+Q 2618 346 2758 554 
+Q 2899 762 2963 1037 
+L 2419 1037 
+Q 2304 730 2067 566 
+Q 1830 403 1466 403 
+Q 1299 403 1145 457 
+Q 992 512 870 611 
+Q 749 710 678 860 
+Q 608 1011 608 1203 
+Q 608 1350 627 1491 
+z
+M 2624 1971 
+L 704 1971 
+Q 762 2163 858 2332 
+Q 954 2502 1094 2630 
+Q 1235 2758 1424 2832 
+Q 1613 2906 1850 2906 
+Q 2074 2906 2227 2826 
+Q 2381 2746 2473 2614 
+Q 2566 2483 2601 2313 
+Q 2637 2144 2624 1971 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-72" d="M 659 3309 
+L -26 0 
+L 512 0 
+L 826 1466 
+Q 864 1651 928 1865 
+Q 992 2080 1101 2240 
+Q 1229 2438 1405 2579 
+Q 1581 2720 1805 2778 
+Q 1901 2803 1965 2806 
+Q 2029 2810 2131 2810 
+L 2208 2810 
+Q 2266 2810 2291 2803 
+L 2419 3386 
+Q 2368 3398 2323 3392 
+Q 2278 3386 2227 3386 
+Q 1811 3386 1513 3162 
+Q 1216 2938 1024 2598 
+L 1011 2598 
+L 1171 3309 
+L 659 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-79" d="M 1043 -557 
+L 3232 3309 
+L 2637 3309 
+L 1248 678 
+L 1235 678 
+L 851 3309 
+L 269 3309 
+L 851 0 
+L 518 -544 
+Q 422 -704 307 -803 
+Q 192 -902 6 -902 
+Q -58 -902 -147 -876 
+Q -237 -851 -301 -813 
+L -397 -1254 
+Q -320 -1293 -217 -1315 
+Q -115 -1338 -19 -1338 
+Q 186 -1338 339 -1277 
+Q 493 -1216 614 -1110 
+Q 736 -1005 838 -861 
+Q 941 -717 1043 -557 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-20" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-70" d="M 653 3309 
+L -307 -1261 
+L 224 -1261 
+L 576 506 
+L 589 506 
+Q 634 339 746 227 
+Q 858 115 1002 48 
+Q 1146 -19 1309 -44 
+Q 1472 -70 1619 -70 
+Q 2054 -70 2396 115 
+Q 2739 301 2972 601 
+Q 3206 902 3331 1276 
+Q 3456 1651 3456 2029 
+Q 3456 2330 3373 2579 
+Q 3290 2829 3123 3008 
+Q 2957 3187 2717 3286 
+Q 2477 3386 2157 3386 
+Q 1824 3386 1565 3270 
+Q 1306 3155 1062 2835 
+L 1050 2835 
+L 1165 3309 
+L 653 3309 
+z
+M 2912 2029 
+Q 2912 1754 2829 1466 
+Q 2746 1178 2579 941 
+Q 2413 704 2169 553 
+Q 1926 403 1600 403 
+Q 1197 403 982 646 
+Q 768 890 768 1261 
+Q 768 1523 854 1811 
+Q 941 2099 1104 2342 
+Q 1267 2586 1510 2746 
+Q 1754 2906 2061 2906 
+Q 2509 2906 2710 2669 
+Q 2912 2432 2912 2029 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-6f" d="M 109 1306 
+Q 109 1005 205 752 
+Q 301 499 480 316 
+Q 659 134 918 32 
+Q 1178 -70 1504 -70 
+Q 1939 -70 2278 102 
+Q 2618 275 2854 566 
+Q 3091 858 3212 1235 
+Q 3334 1613 3334 2016 
+Q 3334 2688 2982 3037 
+Q 2630 3386 1958 3386 
+Q 1523 3386 1180 3213 
+Q 838 3040 598 2752 
+Q 358 2464 233 2086 
+Q 109 1709 109 1306 
+z
+M 653 1312 
+Q 653 1568 733 1849 
+Q 813 2131 973 2364 
+Q 1133 2598 1369 2752 
+Q 1606 2906 1920 2906 
+Q 2144 2906 2307 2832 
+Q 2470 2758 2579 2633 
+Q 2688 2509 2739 2336 
+Q 2790 2163 2790 1971 
+Q 2790 1728 2710 1453 
+Q 2630 1178 2473 944 
+Q 2317 710 2089 556 
+Q 1862 403 1562 403 
+Q 1114 403 883 652 
+Q 653 902 653 1312 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-69" d="M 1331 3904 
+L 1472 4570 
+L 922 4570 
+L 781 3904 
+L 1331 3904 
+z
+M 659 3309 
+L -26 0 
+L 512 0 
+L 1203 3309 
+L 659 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-6e" d="M 666 3309 
+L -26 0 
+L 512 0 
+L 896 1830 
+Q 947 2029 1030 2211 
+Q 1114 2394 1261 2522 
+Q 1414 2688 1635 2797 
+Q 1856 2906 2080 2906 
+Q 2323 2906 2489 2794 
+Q 2656 2682 2656 2445 
+Q 2656 2400 2646 2333 
+Q 2637 2266 2624 2192 
+Q 2611 2118 2598 2051 
+Q 2586 1984 2579 1933 
+L 2157 0 
+L 2701 0 
+L 3104 1888 
+Q 3149 2080 3174 2253 
+Q 3200 2426 3200 2534 
+Q 3200 2976 2973 3181 
+Q 2746 3386 2278 3386 
+Q 1933 3386 1619 3242 
+Q 1306 3098 1101 2810 
+L 1088 2810 
+L 1190 3309 
+L 666 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-74" d="M 1414 3309 
+L 1619 4288 
+L 1075 4288 
+L 870 3309 
+L 314 3309 
+L 211 2829 
+L 768 2829 
+L 333 774 
+Q 320 698 310 634 
+Q 301 570 301 499 
+Q 301 339 361 236 
+Q 422 134 521 73 
+Q 621 13 755 -9 
+Q 890 -32 1043 -32 
+Q 1139 -32 1235 -22 
+Q 1331 -13 1427 0 
+L 1523 499 
+Q 1446 474 1369 458 
+Q 1293 442 1210 442 
+Q 1082 442 982 490 
+Q 883 538 883 666 
+Q 883 723 889 774 
+Q 896 826 902 883 
+L 1312 2829 
+L 1971 2829 
+L 2074 3309 
+L 1414 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-73" d="M 2272 2336 
+L 2816 2336 
+Q 2816 2624 2707 2825 
+Q 2598 3027 2422 3152 
+Q 2246 3277 2022 3331 
+Q 1798 3386 1568 3386 
+Q 1338 3386 1117 3322 
+Q 896 3258 723 3139 
+Q 550 3021 444 2841 
+Q 339 2662 339 2432 
+Q 339 2246 412 2105 
+Q 486 1965 611 1859 
+Q 736 1754 893 1677 
+Q 1050 1600 1216 1536 
+Q 1376 1466 1533 1405 
+Q 1690 1344 1811 1273 
+Q 1933 1203 2009 1116 
+Q 2086 1030 2086 909 
+Q 2086 768 2019 672 
+Q 1952 576 1843 515 
+Q 1734 454 1600 428 
+Q 1466 403 1331 403 
+Q 1158 403 1001 435 
+Q 845 467 726 540 
+Q 608 614 541 739 
+Q 474 864 486 1043 
+L -51 1043 
+Q -51 723 51 508 
+Q 154 294 330 166 
+Q 506 38 749 -16 
+Q 992 -70 1280 -70 
+Q 1523 -70 1763 -16 
+Q 2003 38 2195 160 
+Q 2387 282 2508 477 
+Q 2630 672 2630 947 
+Q 2630 1139 2553 1283 
+Q 2477 1427 2355 1532 
+Q 2234 1638 2077 1721 
+Q 1920 1805 1754 1875 
+Q 1594 1939 1437 2000 
+Q 1280 2061 1155 2131 
+Q 1030 2202 956 2285 
+Q 883 2368 883 2483 
+Q 883 2611 947 2691 
+Q 1011 2771 1110 2819 
+Q 1210 2867 1338 2886 
+Q 1466 2906 1587 2906 
+Q 1875 2906 2080 2762 
+Q 2285 2618 2272 2336 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-61" d="M 339 2310 
 L 883 2310 
 Q 909 2470 992 2582 
 Q 1075 2694 1196 2768 
@@ -3934,266 +4281,7 @@ Q 845 403 662 518
 Q 480 634 480 864 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-5e" d="M 3168 0 
-L 4877 3309 
-L 4288 3309 
-L 3034 678 
-L 3021 678 
-L 2861 3309 
-L 2246 3309 
-L 1056 678 
-L 1043 678 
-L 838 3309 
-L 262 3309 
-L 653 0 
-L 1229 0 
-L 2413 2573 
-L 2426 2573 
-L 2592 0 
-L 3168 0 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-3" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-57" d="M 653 3309 
-L -307 -1261 
-L 224 -1261 
-L 576 506 
-L 589 506 
-Q 634 339 746 227 
-Q 858 115 1002 48 
-Q 1146 -19 1309 -44 
-Q 1472 -70 1619 -70 
-Q 2054 -70 2396 115 
-Q 2739 301 2972 601 
-Q 3206 902 3331 1276 
-Q 3456 1651 3456 2029 
-Q 3456 2330 3373 2579 
-Q 3290 2829 3123 3008 
-Q 2957 3187 2717 3286 
-Q 2477 3386 2157 3386 
-Q 1824 3386 1565 3270 
-Q 1306 3155 1062 2835 
-L 1050 2835 
-L 1165 3309 
-L 653 3309 
-z
-M 2912 2029 
-Q 2912 1754 2829 1466 
-Q 2746 1178 2579 941 
-Q 2413 704 2169 553 
-Q 1926 403 1600 403 
-Q 1197 403 982 646 
-Q 768 890 768 1261 
-Q 768 1523 854 1811 
-Q 941 2099 1104 2342 
-Q 1267 2586 1510 2746 
-Q 1754 2906 2061 2906 
-Q 2509 2906 2710 2669 
-Q 2912 2432 2912 2029 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-56" d="M 109 1306 
-Q 109 1005 205 752 
-Q 301 499 480 316 
-Q 659 134 918 32 
-Q 1178 -70 1504 -70 
-Q 1939 -70 2278 102 
-Q 2618 275 2854 566 
-Q 3091 858 3212 1235 
-Q 3334 1613 3334 2016 
-Q 3334 2688 2982 3037 
-Q 2630 3386 1958 3386 
-Q 1523 3386 1180 3213 
-Q 838 3040 598 2752 
-Q 358 2464 233 2086 
-Q 109 1709 109 1306 
-z
-M 653 1312 
-Q 653 1568 733 1849 
-Q 813 2131 973 2364 
-Q 1133 2598 1369 2752 
-Q 1606 2906 1920 2906 
-Q 2144 2906 2307 2832 
-Q 2470 2758 2579 2633 
-Q 2688 2509 2739 2336 
-Q 2790 2163 2790 1971 
-Q 2790 1728 2710 1453 
-Q 2630 1178 2473 944 
-Q 2317 710 2089 556 
-Q 1862 403 1562 403 
-Q 1114 403 883 652 
-Q 653 902 653 1312 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-50" d="M 1331 3904 
-L 1472 4570 
-L 922 4570 
-L 781 3904 
-L 1331 3904 
-z
-M 659 3309 
-L -26 0 
-L 512 0 
-L 1203 3309 
-L 659 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-55" d="M 666 3309 
-L -26 0 
-L 512 0 
-L 896 1830 
-Q 947 2029 1030 2211 
-Q 1114 2394 1261 2522 
-Q 1414 2688 1635 2797 
-Q 1856 2906 2080 2906 
-Q 2323 2906 2489 2794 
-Q 2656 2682 2656 2445 
-Q 2656 2400 2646 2333 
-Q 2637 2266 2624 2192 
-Q 2611 2118 2598 2051 
-Q 2586 1984 2579 1933 
-L 2157 0 
-L 2701 0 
-L 3104 1888 
-Q 3149 2080 3174 2253 
-Q 3200 2426 3200 2534 
-Q 3200 2976 2973 3181 
-Q 2746 3386 2278 3386 
-Q 1933 3386 1619 3242 
-Q 1306 3098 1101 2810 
-L 1088 2810 
-L 1190 3309 
-L 666 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-5b" d="M 1414 3309 
-L 1619 4288 
-L 1075 4288 
-L 870 3309 
-L 314 3309 
-L 211 2829 
-L 768 2829 
-L 333 774 
-Q 320 698 310 634 
-Q 301 570 301 499 
-Q 301 339 361 236 
-Q 422 134 521 73 
-Q 621 13 755 -9 
-Q 890 -32 1043 -32 
-Q 1139 -32 1235 -22 
-Q 1331 -13 1427 0 
-L 1523 499 
-Q 1446 474 1369 458 
-Q 1293 442 1210 442 
-Q 1082 442 982 490 
-Q 883 538 883 666 
-Q 883 723 889 774 
-Q 896 826 902 883 
-L 1312 2829 
-L 1971 2829 
-L 2074 3309 
-L 1414 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-5a" d="M 2272 2336 
-L 2816 2336 
-Q 2816 2624 2707 2825 
-Q 2598 3027 2422 3152 
-Q 2246 3277 2022 3331 
-Q 1798 3386 1568 3386 
-Q 1338 3386 1117 3322 
-Q 896 3258 723 3139 
-Q 550 3021 444 2841 
-Q 339 2662 339 2432 
-Q 339 2246 412 2105 
-Q 486 1965 611 1859 
-Q 736 1754 893 1677 
-Q 1050 1600 1216 1536 
-Q 1376 1466 1533 1405 
-Q 1690 1344 1811 1273 
-Q 1933 1203 2009 1116 
-Q 2086 1030 2086 909 
-Q 2086 768 2019 672 
-Q 1952 576 1843 515 
-Q 1734 454 1600 428 
-Q 1466 403 1331 403 
-Q 1158 403 1001 435 
-Q 845 467 726 540 
-Q 608 614 541 739 
-Q 474 864 486 1043 
-L -51 1043 
-Q -51 723 51 508 
-Q 154 294 330 166 
-Q 506 38 749 -16 
-Q 992 -70 1280 -70 
-Q 1523 -70 1763 -16 
-Q 2003 38 2195 160 
-Q 2387 282 2508 477 
-Q 2630 672 2630 947 
-Q 2630 1139 2553 1283 
-Q 2477 1427 2355 1532 
-Q 2234 1638 2077 1721 
-Q 1920 1805 1754 1875 
-Q 1594 1939 1437 2000 
-Q 1280 2061 1155 2131 
-Q 1030 2202 956 2285 
-Q 883 2368 883 2483 
-Q 883 2611 947 2691 
-Q 1011 2771 1110 2819 
-Q 1210 2867 1338 2886 
-Q 1466 2906 1587 2906 
-Q 1875 2906 2080 2762 
-Q 2285 2618 2272 2336 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-4d" d="M 762 2829 
-L 147 0 
-L 691 0 
-L 1299 2829 
-L 1939 2829 
-L 2029 3309 
-L 1395 3309 
-Q 1440 3462 1469 3609 
-Q 1498 3757 1558 3875 
-Q 1619 3994 1728 4067 
-Q 1837 4141 2035 4141 
-Q 2093 4141 2157 4131 
-Q 2221 4122 2291 4109 
-L 2381 4570 
-Q 2272 4602 2157 4611 
-Q 2042 4621 1926 4621 
-Q 1600 4621 1417 4509 
-Q 1235 4397 1132 4214 
-Q 1030 4032 976 3795 
-Q 922 3558 858 3309 
-L 294 3309 
-L 198 2829 
-L 762 2829 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-59" d="M 659 3309 
-L -26 0 
-L 512 0 
-L 826 1466 
-Q 864 1651 928 1865 
-Q 992 2080 1101 2240 
-Q 1229 2438 1405 2579 
-Q 1581 2720 1805 2778 
-Q 1901 2803 1965 2806 
-Q 2029 2810 2131 2810 
-L 2208 2810 
-Q 2266 2810 2291 2803 
-L 2419 3386 
-Q 2368 3398 2323 3392 
-Q 2278 3386 2227 3386 
-Q 1811 3386 1513 3162 
-Q 1216 2938 1024 2598 
-L 1011 2598 
-L 1171 3309 
-L 659 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-54" d="M 672 3309 
+     <path id="HelveticaNeue-Italic-6d" d="M 672 3309 
 L -26 0 
 L 512 0 
 L 883 1734 
@@ -4238,185 +4326,153 @@ L 1178 3309
 L 672 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-17" d="M 736 1594 
-Q 736 1754 768 1997 
-Q 800 2240 870 2515 
-Q 941 2790 1049 3065 
-Q 1158 3341 1308 3561 
-Q 1459 3782 1657 3920 
-Q 1856 4058 2099 4058 
-Q 2298 4058 2426 3990 
-Q 2554 3923 2630 3811 
-Q 2707 3699 2742 3552 
-Q 2778 3405 2787 3251 
-Q 2797 3098 2793 2947 
-Q 2790 2797 2790 2669 
-Q 2790 2573 2761 2365 
-Q 2733 2157 2672 1904 
-Q 2611 1651 2512 1385 
-Q 2413 1120 2265 902 
-Q 2118 685 1920 544 
-Q 1722 403 1472 403 
-Q 1069 403 902 726 
-Q 736 1050 736 1594 
-z
-M 160 1683 
-Q 160 1312 221 992 
-Q 282 672 429 435 
-Q 576 198 816 64 
-Q 1056 -70 1414 -70 
-Q 1792 -70 2080 86 
-Q 2368 243 2585 492 
-Q 2803 742 2953 1059 
-Q 3104 1376 3193 1699 
-Q 3283 2022 3324 2316 
-Q 3366 2611 3366 2822 
-Q 3366 3731 3052 4134 
-Q 2739 4538 2144 4538 
-Q 1792 4538 1504 4397 
-Q 1216 4256 998 4025 
-Q 781 3795 621 3494 
-Q 461 3194 358 2877 
-Q 256 2560 208 2249 
-Q 160 1939 160 1683 
+     <path id="HelveticaNeue-Italic-75" d="M 2630 0 
+L 3328 3309 
+L 2784 3309 
+L 2400 1478 
+Q 2355 1274 2249 1078 
+Q 2144 883 1990 732 
+Q 1837 582 1641 492 
+Q 1446 403 1216 403 
+Q 973 403 806 515 
+Q 640 627 640 864 
+Q 640 909 646 976 
+Q 653 1043 665 1116 
+Q 678 1190 691 1260 
+Q 704 1331 717 1376 
+L 1139 3309 
+L 595 3309 
+L 192 1421 
+Q 147 1229 121 1056 
+Q 96 883 96 774 
+Q 96 333 323 131 
+Q 550 -70 1018 -70 
+Q 1363 -70 1676 70 
+Q 1990 211 2195 499 
+L 2208 499 
+L 2106 0 
+L 2630 0 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-14" d="M 269 2035 
-L 166 1523 
-L 2022 1523 
-L 2125 2035 
-L 269 2035 
+     <path id="HelveticaNeue-Italic-64" d="M 2912 0 
+L 3878 4570 
+L 3341 4570 
+L 2989 2803 
+L 2976 2803 
+Q 2925 2970 2816 3082 
+Q 2707 3194 2563 3261 
+Q 2419 3328 2259 3357 
+Q 2099 3386 1946 3386 
+Q 1510 3386 1168 3197 
+Q 826 3008 592 2707 
+Q 358 2406 233 2032 
+Q 109 1658 109 1280 
+Q 109 979 192 729 
+Q 275 480 441 304 
+Q 608 128 851 29 
+Q 1094 -70 1408 -70 
+Q 1741 -70 2000 42 
+Q 2259 154 2502 474 
+L 2515 474 
+L 2400 0 
+L 2912 0 
+z
+M 653 1280 
+Q 653 1555 736 1843 
+Q 819 2131 985 2368 
+Q 1152 2605 1395 2755 
+Q 1638 2906 1965 2906 
+Q 2368 2906 2582 2662 
+Q 2797 2419 2797 2048 
+Q 2797 1792 2710 1501 
+Q 2624 1210 2461 966 
+Q 2298 723 2054 563 
+Q 1811 403 1504 403 
+Q 1056 403 854 640 
+Q 653 877 653 1280 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-4c" d="M 627 1491 
-L 3117 1491 
-Q 3130 1562 3149 1677 
-Q 3168 1792 3168 1920 
-Q 3168 2618 2832 3002 
-Q 2496 3386 1766 3386 
-Q 1427 3386 1116 3232 
-Q 806 3078 572 2796 
-Q 339 2515 201 2121 
-Q 64 1728 64 1254 
-Q 64 1037 128 803 
-Q 192 570 352 374 
-Q 512 179 784 54 
-Q 1056 -70 1466 -70 
-Q 1734 -70 1977 0 
-Q 2221 70 2419 208 
-Q 2618 346 2758 554 
-Q 2899 762 2963 1037 
-L 2419 1037 
-Q 2304 730 2067 566 
-Q 1830 403 1466 403 
-Q 1299 403 1145 457 
-Q 992 512 870 611 
-Q 749 710 678 860 
-Q 608 1011 608 1203 
-Q 608 1350 627 1491 
-z
-M 2624 1971 
-L 704 1971 
-Q 762 2163 858 2332 
-Q 954 2502 1094 2630 
-Q 1235 2758 1424 2832 
-Q 1613 2906 1850 2906 
-Q 2074 2906 2227 2826 
-Q 2381 2746 2473 2614 
-Q 2566 2483 2601 2313 
-Q 2637 2144 2624 1971 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-4a" d="M 2662 2259 
-L 3206 2259 
-Q 3187 2842 2857 3114 
-Q 2528 3386 1965 3386 
-Q 1523 3386 1180 3216 
-Q 838 3046 604 2761 
-Q 371 2477 252 2112 
-Q 134 1747 134 1350 
-Q 134 672 476 301 
-Q 819 -70 1498 -70 
-Q 2080 -70 2470 224 
-Q 2861 518 3008 1082 
-L 2464 1082 
-Q 2349 774 2099 588 
-Q 1850 403 1498 403 
-Q 1267 403 1110 480 
-Q 954 557 858 685 
-Q 762 813 720 985 
-Q 678 1158 678 1350 
-Q 678 1619 761 1897 
-Q 845 2176 1008 2400 
-Q 1171 2624 1411 2765 
-Q 1651 2906 1965 2906 
-Q 2291 2906 2476 2736 
-Q 2662 2566 2662 2259 
+     <path id="HelveticaNeue-Italic-47" d="M 3565 454 
+L 3603 0 
+L 3987 0 
+L 4486 2406 
+L 2496 2406 
+L 2394 1894 
+L 3853 1894 
+Q 3770 1562 3638 1286 
+Q 3507 1011 3308 816 
+Q 3110 621 2838 512 
+Q 2566 403 2202 403 
+Q 1856 403 1603 512 
+Q 1350 621 1184 816 
+Q 1018 1011 934 1286 
+Q 851 1562 851 1894 
+Q 851 2310 969 2716 
+Q 1088 3123 1325 3443 
+Q 1562 3763 1917 3964 
+Q 2272 4166 2752 4166 
+Q 3002 4166 3226 4105 
+Q 3450 4045 3616 3920 
+Q 3782 3795 3881 3603 
+Q 3981 3411 3981 3149 
+L 4589 3149 
+Q 4589 3546 4445 3834 
+Q 4301 4122 4051 4310 
+Q 3802 4499 3466 4588 
+Q 3130 4678 2752 4678 
+Q 2170 4678 1702 4451 
+Q 1235 4224 912 3840 
+Q 589 3456 416 2953 
+Q 243 2451 243 1894 
+Q 243 941 752 419 
+Q 1261 -102 2202 -102 
+Q 2573 -102 2934 32 
+Q 3296 166 3565 454 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-2c" d="M 1011 4570 
+     <path id="HelveticaNeue-Italic-42" d="M 1171 2605 
+L 1478 4058 
+L 2605 4058 
+Q 2746 4058 2902 4042 
+Q 3059 4026 3193 3968 
+Q 3328 3910 3414 3795 
+Q 3501 3680 3501 3475 
+Q 3501 2605 2528 2605 
+L 1171 2605 
+z
+M 998 4570 
 L 45 0 
-L 3226 0 
-L 3341 512 
-L 768 512 
-L 1101 2093 
-L 3475 2093 
-L 3578 2605 
-L 1210 2605 
-L 1517 4058 
-L 4058 4058 
-L 4160 4570 
-L 1011 4570 
+L 2304 0 
+Q 2643 0 2937 99 
+Q 3232 198 3453 380 
+Q 3674 563 3798 825 
+Q 3923 1088 3923 1414 
+Q 3923 1779 3737 2025 
+Q 3552 2272 3238 2362 
+L 3238 2374 
+Q 3443 2406 3603 2512 
+Q 3763 2618 3875 2768 
+Q 3987 2918 4048 3100 
+Q 4109 3283 4109 3475 
+Q 4109 3994 3808 4282 
+Q 3507 4570 2835 4570 
+L 998 4570 
+z
+M 736 512 
+L 1069 2093 
+L 2374 2093 
+Q 2560 2093 2729 2067 
+Q 2899 2042 3030 1971 
+Q 3162 1901 3238 1766 
+Q 3315 1632 3315 1414 
+Q 3315 1101 3184 921 
+Q 3053 742 2873 649 
+Q 2694 557 2508 534 
+Q 2323 512 2208 512 
+L 736 512 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-18" d="M 1805 0 
-L 2771 4538 
-L 2349 4538 
-Q 2246 4346 2083 4198 
-Q 1920 4051 1721 3952 
-Q 1523 3853 1308 3805 
-Q 1094 3757 883 3757 
-L 794 3322 
-Q 1107 3322 1382 3350 
-Q 1658 3379 1965 3450 
-L 1229 0 
-L 1805 0 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-1e" d="M 3610 4006 
-L 3686 4461 
-L 762 4461 
-L 653 3981 
-L 3014 3981 
-Q 2189 3110 1581 2115 
-Q 973 1120 621 0 
-L 1242 0 
-Q 1402 506 1645 1056 
-Q 1888 1606 2195 2140 
-Q 2502 2675 2860 3158 
-Q 3219 3642 3610 4006 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-f" d="M 742 -1261 
-L 1101 -1261 
-Q 922 -742 845 -214 
-Q 768 314 768 858 
-Q 768 1414 880 1923 
-Q 992 2432 1197 2905 
-Q 1402 3379 1690 3820 
-Q 1978 4262 2323 4678 
-L 1875 4678 
-Q 1523 4282 1219 3875 
-Q 915 3469 694 3030 
-Q 474 2592 349 2112 
-Q 224 1632 224 1088 
-Q 224 813 262 502 
-Q 301 192 368 -115 
-Q 435 -422 531 -716 
-Q 627 -1011 742 -1261 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-1a" d="M 1466 2586 
+     <path id="HelveticaNeue-Italic-33" d="M 1466 2586 
 L 1370 2150 
 Q 1574 2150 1776 2131 
 Q 1978 2112 2138 2035 
@@ -4462,45 +4518,50 @@ Q 2125 2618 1904 2595
 Q 1683 2573 1466 2586 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-4b" d="M 2912 0 
-L 3878 4570 
-L 3341 4570 
-L 2989 2803 
-L 2976 2803 
-Q 2925 2970 2816 3082 
-Q 2707 3194 2563 3261 
-Q 2419 3328 2259 3357 
-Q 2099 3386 1946 3386 
-Q 1510 3386 1168 3197 
-Q 826 3008 592 2707 
-Q 358 2406 233 2032 
-Q 109 1658 109 1280 
-Q 109 979 192 729 
-Q 275 480 441 304 
-Q 608 128 851 29 
-Q 1094 -70 1408 -70 
-Q 1741 -70 2000 42 
-Q 2259 154 2502 474 
-L 2515 474 
-L 2400 0 
-L 2912 0 
+     <path id="HelveticaNeue-Italic-30" d="M 736 1594 
+Q 736 1754 768 1997 
+Q 800 2240 870 2515 
+Q 941 2790 1049 3065 
+Q 1158 3341 1308 3561 
+Q 1459 3782 1657 3920 
+Q 1856 4058 2099 4058 
+Q 2298 4058 2426 3990 
+Q 2554 3923 2630 3811 
+Q 2707 3699 2742 3552 
+Q 2778 3405 2787 3251 
+Q 2797 3098 2793 2947 
+Q 2790 2797 2790 2669 
+Q 2790 2573 2761 2365 
+Q 2733 2157 2672 1904 
+Q 2611 1651 2512 1385 
+Q 2413 1120 2265 902 
+Q 2118 685 1920 544 
+Q 1722 403 1472 403 
+Q 1069 403 902 726 
+Q 736 1050 736 1594 
 z
-M 653 1280 
-Q 653 1555 736 1843 
-Q 819 2131 985 2368 
-Q 1152 2605 1395 2755 
-Q 1638 2906 1965 2906 
-Q 2368 2906 2582 2662 
-Q 2797 2419 2797 2048 
-Q 2797 1792 2710 1501 
-Q 2624 1210 2461 966 
-Q 2298 723 2054 563 
-Q 1811 403 1504 403 
-Q 1056 403 854 640 
-Q 653 877 653 1280 
+M 160 1683 
+Q 160 1312 221 992 
+Q 282 672 429 435 
+Q 576 198 816 64 
+Q 1056 -70 1414 -70 
+Q 1792 -70 2080 86 
+Q 2368 243 2585 492 
+Q 2803 742 2953 1059 
+Q 3104 1376 3193 1699 
+Q 3283 2022 3324 2316 
+Q 3366 2611 3366 2822 
+Q 3366 3731 3052 4134 
+Q 2739 4538 2144 4538 
+Q 1792 4538 1504 4397 
+Q 1216 4256 998 4025 
+Q 781 3795 621 3494 
+Q 461 3194 358 2877 
+Q 256 2560 208 2249 
+Q 160 1939 160 1683 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-1f" d="M 666 3322 
+     <path id="HelveticaNeue-Italic-38" d="M 666 3322 
 Q 666 3053 826 2822 
 Q 986 2592 1229 2483 
 L 1229 2470 
@@ -4549,7 +4610,50 @@ Q 1683 2630 1462 2787
 Q 1242 2944 1242 3302 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-13" d="M 250 710 
+     <path id="HelveticaNeue-Italic-4b" d="M 1011 4570 
+L 45 0 
+L 653 0 
+L 979 1542 
+L 1894 2317 
+L 3142 0 
+L 3814 0 
+L 2349 2688 
+L 4550 4570 
+L 3738 4570 
+L 1152 2304 
+L 1139 2317 
+L 1619 4570 
+L 1011 4570 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-2f" d="M 1779 4678 
+L -109 -102 
+L 352 -102 
+L 2246 4678 
+L 1779 4678 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-31" d="M 1805 0 
+L 2771 4538 
+L 2349 4538 
+Q 2246 4346 2083 4198 
+Q 1920 4051 1721 3952 
+Q 1523 3853 1308 3805 
+Q 1094 3757 883 3757 
+L 794 3322 
+Q 1107 3322 1382 3350 
+Q 1658 3379 1965 3450 
+L 1229 0 
+L 1805 0 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-3b" d="M 1344 2598 
+L 1498 3309 
+L 787 3309 
+L 634 2598 
+L 1344 2598 
+z
+M 250 710 
 L 96 0 
 L 454 0 
 Q 422 -109 390 -211 
@@ -4564,101 +4668,220 @@ Q 896 448 960 710
 L 250 710 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-53" d="M 928 4570 
+     <path id="HelveticaNeue-Italic-63" d="M 2662 2259 
+L 3206 2259 
+Q 3187 2842 2857 3114 
+Q 2528 3386 1965 3386 
+Q 1523 3386 1180 3216 
+Q 838 3046 604 2761 
+Q 371 2477 252 2112 
+Q 134 1747 134 1350 
+Q 134 672 476 301 
+Q 819 -70 1498 -70 
+Q 2080 -70 2470 224 
+Q 2861 518 3008 1082 
+L 2464 1082 
+Q 2349 774 2099 588 
+Q 1850 403 1498 403 
+Q 1267 403 1110 480 
+Q 954 557 858 685 
+Q 762 813 720 985 
+Q 678 1158 678 1350 
+Q 678 1619 761 1897 
+Q 845 2176 1008 2400 
+Q 1171 2624 1411 2765 
+Q 1651 2906 1965 2906 
+Q 2291 2906 2476 2736 
+Q 2662 2566 2662 2259 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-6c" d="M 928 4570 
 L -26 0 
 L 512 0 
 L 1472 4570 
 L 928 4570 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-60" d="M 1043 -557 
-L 3232 3309 
-L 2637 3309 
-L 1248 678 
-L 1235 678 
-L 851 3309 
-L 269 3309 
-L 851 0 
-L 518 -544 
-Q 422 -704 307 -803 
-Q 192 -902 6 -902 
-Q -58 -902 -147 -876 
-Q -237 -851 -301 -813 
-L -397 -1254 
-Q -320 -1293 -217 -1315 
-Q -115 -1338 -19 -1338 
-Q 186 -1338 339 -1277 
-Q 493 -1216 614 -1110 
-Q 736 -1005 838 -861 
-Q 941 -717 1043 -557 
+     <path id="HelveticaNeue-Italic-62" d="M 934 4570 
+L -26 0 
+L 454 0 
+L 576 614 
+L 589 614 
+Q 614 486 707 364 
+Q 800 243 944 147 
+Q 1088 51 1280 -9 
+Q 1472 -70 1702 -70 
+Q 2125 -70 2448 102 
+Q 2771 275 2995 556 
+Q 3219 838 3334 1203 
+Q 3450 1568 3450 1958 
+Q 3450 2278 3370 2540 
+Q 3290 2803 3130 2988 
+Q 2970 3174 2726 3280 
+Q 2483 3386 2150 3386 
+Q 1843 3386 1584 3254 
+Q 1325 3123 1139 2886 
+L 1126 2899 
+L 1478 4570 
+L 934 4570 
+z
+M 2906 1958 
+Q 2906 1722 2829 1446 
+Q 2752 1171 2598 940 
+Q 2445 710 2221 556 
+Q 1997 403 1702 403 
+Q 1299 403 1049 620 
+Q 800 838 800 1229 
+Q 800 1491 877 1785 
+Q 954 2080 1117 2329 
+Q 1280 2579 1536 2742 
+Q 1792 2906 2150 2906 
+Q 2342 2906 2483 2832 
+Q 2624 2758 2717 2630 
+Q 2810 2502 2858 2329 
+Q 2906 2157 2906 1958 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-5c" d="M 2630 0 
-L 3328 3309 
-L 2784 3309 
-L 2400 1478 
-Q 2355 1274 2249 1078 
-Q 2144 883 1990 732 
-Q 1837 582 1641 492 
-Q 1446 403 1216 403 
-Q 973 403 806 515 
-Q 640 627 640 864 
-Q 640 909 646 976 
-Q 653 1043 665 1116 
-Q 678 1190 691 1260 
-Q 704 1331 717 1376 
-L 1139 3309 
-L 595 3309 
-L 192 1421 
-Q 147 1229 121 1056 
-Q 96 883 96 774 
-Q 96 333 323 131 
-Q 550 -70 1018 -70 
-Q 1363 -70 1676 70 
-Q 1990 211 2195 499 
-L 2208 499 
-L 2106 0 
-L 2630 0 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-10" d="M -742 -1261 
-L -294 -1261 
-Q 51 -858 352 -454 
-Q 653 -51 873 381 
-Q 1094 813 1222 1289 
-Q 1350 1766 1350 2317 
-Q 1350 2598 1312 2905 
-Q 1274 3213 1203 3520 
-Q 1133 3827 1040 4124 
-Q 947 4422 832 4678 
-L 474 4678 
-Q 653 4160 729 3625 
-Q 806 3091 806 2547 
-Q 806 1997 694 1485 
-Q 582 973 380 499 
-Q 179 26 -109 -416 
-Q -397 -858 -742 -1261 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-15" d="M 250 710 
+     <path id="HelveticaNeue-Italic-2e" d="M 250 710 
 L 96 0 
 L 806 0 
 L 960 710 
 L 250 710 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-3b" d="M 4064 4058 
-L 4179 4570 
-L 493 4570 
-L 384 4058 
-L 1920 4058 
-L 1062 0 
-L 1670 0 
-L 2528 4058 
-L 4064 4058 
+     <path id="HelveticaNeue-Italic-35" d="M 3251 3981 
+L 3347 4461 
+L 1050 4461 
+L 346 2067 
+L 832 2067 
+Q 947 2272 1171 2390 
+Q 1395 2509 1638 2509 
+Q 2080 2509 2310 2272 
+Q 2541 2035 2541 1594 
+Q 2541 1350 2467 1132 
+Q 2394 915 2256 752 
+Q 2118 589 1913 496 
+Q 1709 403 1440 403 
+Q 621 403 621 1216 
+L 45 1216 
+Q 45 595 416 262 
+Q 787 -70 1408 -70 
+Q 1760 -70 2048 26 
+Q 2336 122 2605 352 
+Q 2874 595 2995 924 
+Q 3117 1254 3117 1619 
+Q 3117 1907 3033 2160 
+Q 2950 2413 2787 2595 
+Q 2624 2778 2387 2883 
+Q 2150 2989 1843 2989 
+Q 1632 2989 1421 2928 
+Q 1210 2867 1043 2739 
+L 1030 2752 
+L 1389 3981 
+L 3251 3981 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-4f" d="M 934 4570 
+     <path id="HelveticaNeue-Italic-2013" d="M -38 2035 
+L -141 1523 
+L 3053 1523 
+L 3155 2035 
+L -38 2035 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-25" d="M 506 2906 
+Q 506 2464 752 2221 
+Q 998 1978 1427 1978 
+Q 1747 1978 1974 2131 
+Q 2202 2285 2346 2521 
+Q 2490 2758 2557 3046 
+Q 2624 3334 2624 3610 
+Q 2624 4538 1690 4538 
+Q 1382 4538 1158 4381 
+Q 934 4224 790 3981 
+Q 646 3738 576 3453 
+Q 506 3168 506 2906 
+z
+M 3718 877 
+Q 3718 1043 3763 1257 
+Q 3808 1472 3901 1667 
+Q 3994 1862 4141 1996 
+Q 4288 2131 4499 2131 
+Q 4966 2131 4966 1587 
+Q 4966 1389 4928 1158 
+Q 4890 928 4803 729 
+Q 4717 531 4576 403 
+Q 4435 275 4224 275 
+Q 3936 275 3827 428 
+Q 3718 582 3718 877 
+z
+M 3283 851 
+Q 3283 410 3529 170 
+Q 3776 -70 4205 -70 
+Q 4525 -70 4752 80 
+Q 4979 230 5123 467 
+Q 5267 704 5334 992 
+Q 5402 1280 5402 1555 
+Q 5402 2483 4467 2483 
+Q 4160 2483 3936 2326 
+Q 3712 2170 3568 1926 
+Q 3424 1683 3353 1398 
+Q 3283 1114 3283 851 
+z
+M 4122 4640 
+L 1338 -173 
+L 1747 -173 
+L 4531 4640 
+L 4122 4640 
+z
+M 941 2931 
+Q 941 3098 985 3312 
+Q 1030 3526 1123 3721 
+Q 1216 3917 1363 4051 
+Q 1510 4186 1722 4186 
+Q 2189 4186 2189 3642 
+Q 2189 3443 2150 3212 
+Q 2112 2982 2025 2784 
+Q 1939 2586 1798 2458 
+Q 1658 2330 1446 2330 
+Q 1158 2330 1049 2483 
+Q 941 2637 941 2931 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-2c" d="M 250 710 
+L 96 0 
+L 454 0 
+Q 422 -109 390 -211 
+Q 358 -314 307 -400 
+Q 256 -486 176 -547 
+Q 96 -608 -32 -627 
+L -96 -934 
+Q 237 -909 419 -745 
+Q 602 -582 701 -348 
+Q 800 -115 848 166 
+Q 896 448 960 710 
+L 250 710 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-77" d="M 3168 0 
+L 4877 3309 
+L 4288 3309 
+L 3034 678 
+L 3021 678 
+L 2861 3309 
+L 2246 3309 
+L 1056 678 
+L 1043 678 
+L 838 3309 
+L 262 3309 
+L 653 0 
+L 1229 0 
+L 2413 2573 
+L 2426 2573 
+L 2592 0 
+L 3168 0 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-68" d="M 934 4570 
 L -26 0 
 L 512 0 
 L 896 1830 
@@ -4686,23 +4909,36 @@ L 1478 4570
 L 934 4570 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-52" d="M 934 4570 
-L -26 0 
-L 512 0 
-L 762 1178 
-L 1414 1760 
-L 2061 0 
-L 2669 0 
-L 1850 2086 
-L 3290 3309 
-L 2579 3309 
-L 915 1869 
-L 902 1882 
-L 1472 4570 
-L 934 4570 
+     <path id="HelveticaNeue-Italic-7e" d="M 3398 1722 
+L 3168 2042 
+Q 3110 1958 3052 1872 
+Q 2995 1786 2928 1715 
+Q 2861 1645 2781 1600 
+Q 2701 1555 2605 1555 
+Q 2477 1555 2304 1644 
+Q 2131 1734 1952 1811 
+Q 1766 1894 1587 1955 
+Q 1408 2016 1242 2016 
+Q 1082 2016 957 1968 
+Q 832 1920 733 1843 
+Q 634 1766 563 1667 
+Q 493 1568 442 1466 
+L 672 1146 
+Q 710 1229 758 1315 
+Q 806 1402 873 1472 
+Q 941 1542 1024 1587 
+Q 1107 1632 1210 1632 
+Q 1434 1632 1613 1552 
+Q 1792 1472 1946 1382 
+Q 2106 1293 2262 1232 
+Q 2419 1171 2598 1171 
+Q 2746 1171 2864 1219 
+Q 2982 1267 3078 1344 
+Q 3174 1421 3251 1520 
+Q 3328 1619 3398 1722 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-19" d="M 435 2995 
+     <path id="HelveticaNeue-Italic-32" d="M 435 2995 
 L 1011 2995 
 Q 1024 3206 1094 3401 
 Q 1165 3597 1289 3741 
@@ -4743,164 +4979,7 @@ Q 717 3917 595 3632
 Q 474 3347 435 2995 
 z
 " transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-5d" d="M 1325 0 
-L 3162 3309 
-L 2573 3309 
-L 1139 557 
-L 1126 557 
-L 845 3309 
-L 269 3309 
-L 742 0 
-L 1325 0 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-1c" d="M 3251 3981 
-L 3347 4461 
-L 1050 4461 
-L 346 2067 
-L 832 2067 
-Q 947 2272 1171 2390 
-Q 1395 2509 1638 2509 
-Q 2080 2509 2310 2272 
-Q 2541 2035 2541 1594 
-Q 2541 1350 2467 1132 
-Q 2394 915 2256 752 
-Q 2118 589 1913 496 
-Q 1709 403 1440 403 
-Q 621 403 621 1216 
-L 45 1216 
-Q 45 595 416 262 
-Q 787 -70 1408 -70 
-Q 1760 -70 2048 26 
-Q 2336 122 2605 352 
-Q 2874 595 2995 924 
-Q 3117 1254 3117 1619 
-Q 3117 1907 3033 2160 
-Q 2950 2413 2787 2595 
-Q 2624 2778 2387 2883 
-Q 2150 2989 1843 2989 
-Q 1632 2989 1421 2928 
-Q 1210 2867 1043 2739 
-L 1030 2752 
-L 1389 3981 
-L 3251 3981 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-16" d="M 1779 4678 
-L -109 -102 
-L 352 -102 
-L 2246 4678 
-L 1779 4678 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-2e" d="M 3565 454 
-L 3603 0 
-L 3987 0 
-L 4486 2406 
-L 2496 2406 
-L 2394 1894 
-L 3853 1894 
-Q 3770 1562 3638 1286 
-Q 3507 1011 3308 816 
-Q 3110 621 2838 512 
-Q 2566 403 2202 403 
-Q 1856 403 1603 512 
-Q 1350 621 1184 816 
-Q 1018 1011 934 1286 
-Q 851 1562 851 1894 
-Q 851 2310 969 2716 
-Q 1088 3123 1325 3443 
-Q 1562 3763 1917 3964 
-Q 2272 4166 2752 4166 
-Q 3002 4166 3226 4105 
-Q 3450 4045 3616 3920 
-Q 3782 3795 3881 3603 
-Q 3981 3411 3981 3149 
-L 4589 3149 
-Q 4589 3546 4445 3834 
-Q 4301 4122 4051 4310 
-Q 3802 4499 3466 4588 
-Q 3130 4678 2752 4678 
-Q 2170 4678 1702 4451 
-Q 1235 4224 912 3840 
-Q 589 3456 416 2953 
-Q 243 2451 243 1894 
-Q 243 941 752 419 
-Q 1261 -102 2202 -102 
-Q 2573 -102 2934 32 
-Q 3296 166 3565 454 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-37" d="M 1158 2381 
-L 1510 4058 
-L 2797 4058 
-Q 2950 4058 3084 4019 
-Q 3219 3981 3321 3894 
-Q 3424 3808 3485 3664 
-Q 3546 3520 3546 3309 
-Q 3546 2899 3290 2640 
-Q 3034 2381 2534 2381 
-L 1158 2381 
-z
-M 998 4570 
-L 45 0 
-L 653 0 
-L 1050 1869 
-L 2406 1869 
-Q 2912 1869 3248 2013 
-Q 3584 2157 3785 2374 
-Q 3987 2592 4070 2845 
-Q 4154 3098 4154 3309 
-Q 4154 3942 3805 4256 
-Q 3456 4570 2797 4570 
-L 998 4570 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-3c" d="M 4090 1830 
-L 4659 4570 
-L 4051 4570 
-L 3475 1830 
-Q 3405 1510 3318 1248 
-Q 3232 986 3081 797 
-Q 2931 608 2694 505 
-Q 2458 403 2080 403 
-Q 1408 403 1126 729 
-Q 845 1056 998 1728 
-L 1600 4570 
-L 992 4570 
-L 422 1882 
-Q 224 915 643 406 
-Q 1062 -102 2080 -102 
-Q 2368 -102 2640 -44 
-Q 2912 13 3145 141 
-Q 3379 269 3561 470 
-Q 3744 672 3859 954 
-Q 3917 1088 3974 1325 
-Q 4032 1562 4090 1830 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-22" d="M 1344 2598 
-L 1498 3309 
-L 787 3309 
-L 634 2598 
-L 1344 2598 
-z
-M 250 710 
-L 96 0 
-L 454 0 
-Q 422 -109 390 -211 
-Q 358 -314 307 -400 
-Q 256 -486 176 -547 
-Q 96 -608 -32 -627 
-L -96 -934 
-Q 237 -909 419 -745 
-Q 602 -582 701 -348 
-Q 800 -115 848 166 
-Q 896 448 960 710 
-L 250 710 
-z
-" transform="scale(0.015625)"/>
-     <path id="HelveticaNeue-Italic-c4" d="M 762 2829 
+     <path id="HelveticaNeue-Italic-66" d="M 762 2829 
 L 147 0 
 L 691 0 
 L 1299 2829 
@@ -4924,225 +5003,293 @@ L 294 3309
 L 198 2829 
 L 762 2829 
 z
-M 3232 3904 
-L 3373 4570 
-L 2822 4570 
-L 2682 3904 
-L 3232 3904 
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-67" d="M 2938 480 
+L 3533 3309 
+L 3021 3309 
+L 2918 2701 
+L 2906 2701 
+L 2906 2714 
+Q 2867 2867 2768 2992 
+Q 2669 3117 2525 3203 
+Q 2381 3290 2211 3338 
+Q 2042 3386 1856 3386 
+Q 1453 3386 1133 3203 
+Q 813 3021 592 2729 
+Q 371 2438 252 2073 
+Q 134 1709 134 1344 
+Q 134 1043 214 793 
+Q 294 544 448 361 
+Q 602 179 835 80 
+Q 1069 -19 1376 -19 
+Q 1690 -19 1958 96 
+Q 2227 211 2406 480 
+L 2419 467 
+Q 2355 224 2281 -16 
+Q 2208 -256 2080 -441 
+Q 1952 -627 1750 -742 
+Q 1549 -858 1235 -858 
+Q 1082 -858 934 -835 
+Q 787 -813 675 -752 
+Q 563 -691 489 -585 
+Q 416 -480 403 -314 
+L -134 -314 
+Q -128 -589 -16 -784 
+Q 96 -979 275 -1100 
+Q 454 -1222 688 -1280 
+Q 922 -1338 1178 -1338 
+Q 1715 -1338 2092 -1126 
+Q 2470 -915 2682 -416 
+Q 2752 -243 2816 -9 
+Q 2880 224 2938 480 
 z
-M 2560 3309 
-L 1869 0 
-L 2413 0 
-L 3104 3309 
-L 2560 3309 
+M 678 1344 
+Q 678 1574 755 1846 
+Q 832 2118 979 2352 
+Q 1126 2586 1344 2746 
+Q 1562 2906 1850 2906 
+Q 2278 2906 2486 2669 
+Q 2694 2432 2694 2042 
+Q 2694 1792 2620 1513 
+Q 2547 1235 2400 998 
+Q 2253 762 2025 608 
+Q 1798 454 1491 454 
+Q 1286 454 1132 528 
+Q 979 602 880 723 
+Q 781 845 729 1005 
+Q 678 1165 678 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-54" d="M 4064 4058 
+L 4179 4570 
+L 493 4570 
+L 384 4058 
+L 1920 4058 
+L 1062 0 
+L 1670 0 
+L 2528 4058 
+L 4064 4058 
+z
+" transform="scale(0.015625)"/>
+     <path id="HelveticaNeue-Italic-34" d="M 1965 1062 
+L 1734 0 
+L 2278 0 
+L 2509 1062 
+L 3110 1062 
+L 3206 1542 
+L 2605 1542 
+L 3232 4538 
+L 2771 4538 
+L 83 1600 
+L -19 1062 
+L 1965 1062 
+z
+M 602 1542 
+L 2477 3597 
+L 2490 3597 
+L 2061 1542 
+L 602 1542 
 z
 " transform="scale(0.015625)"/>
     </defs>
-    <use xlink:href="#HelveticaNeue-Italic-39"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(68.5 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5e" transform="translate(120.40625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(196.3125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(224.109375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(283.40625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(340.8125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(363.015625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(418.609375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(450.109375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(498.203125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4d" transform="translate(526 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(555.59375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(587.09375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-54" transform="translate(644.5 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(729.703125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(757.5 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-17" transform="translate(816.796875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-14" transform="translate(872.390625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(911.296875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(970.59375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(1024.296875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4d" transform="translate(1057.59375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(1087.1875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(1144.59375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-54" transform="translate(1177.890625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(1263.09375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(1315 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(1370.59375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(1424.296875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(1478 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-2c" transform="translate(1505.796875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-18" transform="translate(1566.890625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1e" transform="translate(1622.484375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(1678.078125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-f" transform="translate(1705.875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1a" transform="translate(1731.78125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4b" transform="translate(1787.375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(1846.671875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1a" transform="translate(1900.375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1a" transform="translate(1955.96875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(2011.5625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4d" transform="translate(2063.46875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1f" transform="translate(2093.0625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(2148.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-13" transform="translate(2202.359375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(2230.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-53" transform="translate(2257.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-60" transform="translate(2280.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(2328.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(2361.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(2383.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(2431.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(2459.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-53" transform="translate(2513.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5c" transform="translate(2535.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(2591.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(2639.234375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(2670.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(2724.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-10" transform="translate(2757.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-15" transform="translate(2783.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(2811.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3b" transform="translate(2839.234375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4f" transform="translate(2896.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(2952.234375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(3005.9375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(3033.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(3093.03125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(3150.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(3198.53125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-14" transform="translate(3230.03125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(3268.9375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(3326.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(3385.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(3417.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-54" transform="translate(3439.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(3524.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(3546.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(3594.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(3646.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(3678.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(3700.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(3757.859375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(3813.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(3841.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(3872.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-14" transform="translate(3926.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(3965.359375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5c" transform="translate(3998.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(4054.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(4109.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(4137.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(4169.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(4222.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(4282.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(4313.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4b" transform="translate(4371.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5c" transform="translate(4430.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(4485.9375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(4539.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(4593.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(4641.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(4669.234375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4f" transform="translate(4700.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(4756.328125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(4810.03125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(4837.828125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(4897.125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(4950.828125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-52" transform="translate(5002.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(5050.828125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5e" transform="translate(5078.625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(5154.53125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(5176.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4f" transform="translate(5208.234375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(5263.828125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(5286.03125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(5341.625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-55" transform="translate(5369.421875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(5425.015625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(5482.421875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(5504.625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(5552.71875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(5606.421875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-f" transform="translate(5634.21875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-19" transform="translate(5660.125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-13" transform="translate(5715.71875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1e" transform="translate(5743.515625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1a" transform="translate(5799.109375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1f" transform="translate(5854.703125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(5910.296875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5d" transform="translate(5938.09375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(5986.1875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(6034.28125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-19" transform="translate(6062.078125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-13" transform="translate(6117.671875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1e" transform="translate(6145.46875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-18" transform="translate(6201.0625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-1c" transform="translate(6256.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(6312.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(6340.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(6371.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-52" transform="translate(6428.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-16" transform="translate(6477.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(6510.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-16" transform="translate(6558.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-2e" transform="translate(6591.734375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-37" transform="translate(6667.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3c" transform="translate(6732.4375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-10" transform="translate(6804.640625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-22" transform="translate(6830.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(6858.34375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5e" transform="translate(6886.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(6962.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4b" transform="translate(6984.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(7043.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-14" transform="translate(7097.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-2c" transform="translate(7136.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-37" transform="translate(7197.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(7262.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4b" transform="translate(7289.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(7349.140625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(7402.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-56" transform="translate(7456.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4b" transform="translate(7513.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(7573.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(7626.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(7654.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(7706.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-54" transform="translate(7739.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(7825.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(7873.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-48" transform="translate(7901.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(7952.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(7984.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(8038.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(8065.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-53" transform="translate(8119.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5c" transform="translate(8141.859375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(8197.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(8245.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(8277.046875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(8330.75 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-14" transform="translate(8358.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5a" transform="translate(8397.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-57" transform="translate(8445.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(8504.84375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(8558.546875 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-50" transform="translate(8612.25 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-c4" transform="translate(8634.453125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4a" transform="translate(8686.359375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-3" transform="translate(8740.0625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-5b" transform="translate(8767.859375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4f" transform="translate(8799.359375 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(8854.953125 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-59" transform="translate(8908.65625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-4c" transform="translate(8940.15625 0)"/>
-    <use xlink:href="#HelveticaNeue-Italic-15" transform="translate(8993.859375 0)"/>
+    <use xlink:href="#HelveticaNeue-Italic-45"/>
+    <use xlink:href="#HelveticaNeue-Italic-76" x="61.099991"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="109.199982"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="162.899979"/>
+    <use xlink:href="#HelveticaNeue-Italic-79" x="196.199966"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="244.299957"/>
+    <use xlink:href="#HelveticaNeue-Italic-70" x="272.099945"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="331.399933"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="388.799927"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="410.999924"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="466.599915"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="498.099899"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="525.899887"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="548.099884"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="596.199875"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="623.999863"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="675.899857"/>
+    <use xlink:href="#HelveticaNeue-Italic-6d" x="703.699844"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="788.899826"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="842.599823"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="894.499817"/>
+    <use xlink:href="#HelveticaNeue-Italic-75" x="942.599808"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="998.199799"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="1029.749786"/>
+    <use xlink:href="#HelveticaNeue-Italic-64" x="1083.449783"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="1142.749771"/>
+    <use xlink:href="#HelveticaNeue-Italic-47" x="1170.549759"/>
+    <use xlink:href="#HelveticaNeue-Italic-42" x="1246.449753"/>
+    <use xlink:href="#HelveticaNeue-Italic-33" x="1314.949738"/>
+    <use xlink:href="#HelveticaNeue-Italic-30" x="1370.549728"/>
+    <use xlink:href="#HelveticaNeue-Italic-30" x="1426.149719"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="1481.74971"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="1509.549698"/>
+    <use xlink:href="#HelveticaNeue-Italic-75" x="1542.849686"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="1598.449677"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="1654.049667"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="1681.849655"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="1733.749649"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="1765.249634"/>
+    <use xlink:href="#HelveticaNeue-Italic-38" x="1793.049622"/>
+    <use xlink:href="#HelveticaNeue-Italic-4b" x="1848.649612"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="1915.349609"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="1943.149597"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="1965.349594"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="2020.949585"/>
+    <use xlink:href="#HelveticaNeue-Italic-2f" x="2048.749573"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="2082.049561"/>
+    <use xlink:href="#HelveticaNeue-Italic-31" x="2109.849548"/>
+    <use xlink:href="#HelveticaNeue-Italic-4b" x="2165.449539"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="2232.149536"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="2259.949524"/>
+    <use xlink:href="#HelveticaNeue-Italic-75" x="2317.349518"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="2372.949509"/>
+    <use xlink:href="#HelveticaNeue-Italic-3b" x="2404.449493"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="2432.249481"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="2460.049469"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="2491.599457"/>
+    <use xlink:href="#HelveticaNeue-Italic-70" x="2545.299454"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="2604.599442"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="2658.299438"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="2710.199432"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="2741.699417"/>
+    <use xlink:href="#HelveticaNeue-Italic-64" x="2795.399414"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="2854.699402"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="2882.49939"/>
+    <use xlink:href="#HelveticaNeue-Italic-64" x="2904.699387"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="2963.999374"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="3017.699371"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="3073.299362"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="3104.799347"/>
+    <use xlink:href="#HelveticaNeue-Italic-63" x="3126.999344"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="3180.699341"/>
+    <use xlink:href="#HelveticaNeue-Italic-6c" x="3232.599335"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="3254.799332"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="3282.599319"/>
+    <use xlink:href="#HelveticaNeue-Italic-75" x="3315.899307"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="3371.499298"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="3427.099289"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="3475.19928"/>
+    <use xlink:href="#HelveticaNeue-Italic-76" x="3502.999268"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="3551.099258"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="3602.999252"/>
+    <use xlink:href="#HelveticaNeue-Italic-79" x="3636.29924"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="3684.399231"/>
+    <use xlink:href="#HelveticaNeue-Italic-62" x="3712.199219"/>
+    <use xlink:href="#HelveticaNeue-Italic-79" x="3771.499207"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="3819.599197"/>
+    <use xlink:href="#HelveticaNeue-Italic-30" x="3847.399185"/>
+    <use xlink:href="#HelveticaNeue-Italic-2e" x="3902.999176"/>
+    <use xlink:href="#HelveticaNeue-Italic-35" x="3930.799164"/>
+    <use xlink:href="#HelveticaNeue-Italic-2013" x="3986.399155"/>
+    <use xlink:href="#HelveticaNeue-Italic-31" x="4036.399139"/>
+    <use xlink:href="#HelveticaNeue-Italic-25" x="4091.99913"/>
+    <use xlink:href="#HelveticaNeue-Italic-2c" x="4184.599121"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="4212.399109"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="4240.199097"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="4288.299088"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="4345.699081"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="4373.499069"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="4425.399063"/>
+    <use xlink:href="#HelveticaNeue-Italic-6d" x="4458.699051"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="4543.899033"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="4591.999023"/>
+    <use xlink:href="#HelveticaNeue-Italic-77" x="4619.799011"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="4695.699005"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="4717.899002"/>
+    <use xlink:href="#HelveticaNeue-Italic-68" x="4749.398987"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="4804.998978"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="4827.198975"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="4882.798965"/>
+    <use xlink:href="#HelveticaNeue-Italic-7e" x="4910.598953"/>
+    <use xlink:href="#HelveticaNeue-Italic-32" x="4970.598938"/>
+    <use xlink:href="#HelveticaNeue-Italic-25" x="5026.198929"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="5118.79892"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="5146.598907"/>
+    <use xlink:href="#HelveticaNeue-Italic-66" x="5203.998901"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="5233.598892"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="5261.39888"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="5318.798874"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="5374.398865"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="5428.098862"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="5455.898849"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="5507.798843"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="5563.398834"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="5620.798828"/>
+    <use xlink:href="#HelveticaNeue-Italic-68" x="5652.298813"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="5707.898804"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="5761.598801"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="5794.898788"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="5822.698776"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="5874.59877"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="5906.148758"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="5959.848755"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="5987.648743"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="6009.84874"/>
+    <use xlink:href="#HelveticaNeue-Italic-64" x="6065.44873"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="6124.748718"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="6146.948715"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="6195.048706"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="6226.548691"/>
+    <use xlink:href="#HelveticaNeue-Italic-6e" x="6248.748688"/>
+    <use xlink:href="#HelveticaNeue-Italic-67" x="6304.348679"/>
+    <use xlink:href="#HelveticaNeue-Italic-75" x="6361.748672"/>
+    <use xlink:href="#HelveticaNeue-Italic-69" x="6417.348663"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="6439.54866"/>
+    <use xlink:href="#HelveticaNeue-Italic-68" x="6487.648651"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="6543.248642"/>
+    <use xlink:href="#HelveticaNeue-Italic-62" x="6595.148636"/>
+    <use xlink:href="#HelveticaNeue-Italic-6c" x="6654.448624"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="6676.648621"/>
+    <use xlink:href="#HelveticaNeue-Italic-2e" x="6730.348618"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="6758.148605"/>
+    <use xlink:href="#HelveticaNeue-Italic-54" x="6785.948593"/>
+    <use xlink:href="#HelveticaNeue-Italic-68" x="6843.348587"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="6898.948578"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="6952.648575"/>
+    <use xlink:href="#HelveticaNeue-Italic-66" x="6980.448563"/>
+    <use xlink:href="#HelveticaNeue-Italic-70" x="7010.048553"/>
+    <use xlink:href="#HelveticaNeue-Italic-34" x="7069.348541"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="7124.948532"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="7152.74852"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="7204.648514"/>
+    <use xlink:href="#HelveticaNeue-Italic-6d" x="7237.948502"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="7323.148483"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="7371.248474"/>
+    <use xlink:href="#HelveticaNeue-Italic-63" x="7399.048462"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="7452.748459"/>
+    <use xlink:href="#HelveticaNeue-Italic-6d" x="7510.148453"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="7595.348434"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="7649.048431"/>
+    <use xlink:href="#HelveticaNeue-Italic-66" x="7676.848419"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="7706.44841"/>
+    <use xlink:href="#HelveticaNeue-Italic-6f" x="7737.998398"/>
+    <use xlink:href="#HelveticaNeue-Italic-6d" x="7795.398392"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="7880.598373"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="7908.398361"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="7960.298355"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="7988.098343"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="8036.198334"/>
+    <use xlink:href="#HelveticaNeue-Italic-70" x="8089.898331"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="8149.198318"/>
+    <use xlink:href="#HelveticaNeue-Italic-72" x="8201.098312"/>
+    <use xlink:href="#HelveticaNeue-Italic-61" x="8234.3983"/>
+    <use xlink:href="#HelveticaNeue-Italic-74" x="8286.298294"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="8317.798279"/>
+    <use xlink:href="#HelveticaNeue-Italic-20" x="8371.498276"/>
+    <use xlink:href="#HelveticaNeue-Italic-73" x="8399.298264"/>
+    <use xlink:href="#HelveticaNeue-Italic-77" x="8447.398254"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="8523.298248"/>
+    <use xlink:href="#HelveticaNeue-Italic-65" x="8576.998245"/>
+    <use xlink:href="#HelveticaNeue-Italic-70" x="8630.698242"/>
+    <use xlink:href="#HelveticaNeue-Italic-2e" x="8689.99823"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc898bb3ed9">
-   <rect x="56.7352" y="52.3125" width="736.388" height="342.083"/>
+  <clipPath id="p1582a3b38b">
+   <rect x="53.1648" y="43.387969" width="781.2" height="342.72"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
Refreshes the PD-disaggregation Pareto figure in the Kimi K3 day-0 post with the latest sweep.

### Figure

`fig-pareto-pd.svg` regenerated from **69 measured GB300 runs across 14 prefill × decode arms**, up from 57 across 10. The 12 new fp4 runs move both ends of the frontier:

| | before | after |
|---|---|---|
| throughput end | 2,633 tok/s per GPU | **2,808** tok/s per GPU |
| interactive end | 86.8 tok/s per user | **115.8** tok/s per user |

Every legend entry now names the prefill topology, the decode topology and the P:D ratio — e.g. `2×PP8 → DCP8 dp2 EP16 · 2P:1D` — so each arm is readable without the table. Plot style is unchanged (same canvas, palette, grid, spines, fonts, frontier weight and legend placement); the y-axis now closes at 3,000 so the peak reads against a real ceiling.

### Text

- Caption rewritten around the new peak and the extended range.
- Alt text updated to match.
- The intro no longer says prefill is "chunked PP8 throughout" — the fp4 arms use TP8 prefill, so that claim no longer holds.

### Notes for review

- The highlights bullet still cites **2,633** tok/s per GPU for PP prefill + CP decode. That number is still correct for that specific composition, but a reader now sees 2,633 up top and 2,808 in the figure. Happy to reframe the bullet if you'd prefer them aligned.
- The new arms are labelled `fp4` from the source sweep's `FP4 · disagg-multinode` field. If that means something narrower than the whole decode path, the legend suffix and footnote wording should be tightened.
- The source report's `P:D` column reports the prefill *parallel degree* rather than the instance count for the PP8-prefill rows (`8P:1D` at 8+8 GPUs, `8P:3D` at 8+24), while writing `1P:2D` for the TP8-prefill rows. Normalised to instance counts here to match the convention the existing rows use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)