### PR TITLE
Align Kimi K3 highlight with the measured serving peak

### DIFF
--- a/blog/2026-07-27-kimi-k3-day0-support.md
+++ b/blog/2026-07-27-kimi-k3-day0-support.md
@@ -26,8 +26,8 @@ it took.
 - **DSpark speculative decoding, with [a draft model we trained for K3](https://huggingface.co/RadixArk/Kimi-K3-DSpark)**: batch-1 decode
   reaches ~423 tok/s. ReplaySSM handles the KDA state, replaying raw inputs instead of
   snapshotting per step, a roughly 32x cut in draft-window memory.
-- **Parallelism split by phase**: chunked pipeline-parallel prefill and context-parallel
-  decode, composing under PD disaggregation to **2,633** tok/s per GPU.
+- **Parallelism split by phase**: chunked pipeline-parallel prefill and tensor-parallel
+  decode, composing under PD disaggregation to **2,808** tok/s per GPU.
 - **LoRA RL with Miles on the native MXFP4 checkpoint**, colocated trainer and rollout
   on the same GPUs: AIME-2024 43.3% to 76.7% over a 12-hour run.
 


### PR DESCRIPTION
The highlights bullet for parallelism still quoted **2,633** tok/s per GPU and named context-parallel decode. Since the frontier figure was regenerated in #372, the peak arm is `PP8 → TP8 · 1P:1D · fp4` at **2,808** tok/s per GPU, with the `2×PP8 → 2×DCP8` composition just behind at 2,633.

This points the bullet at the arm that actually tops the chart:

> - **Parallelism split by phase**: chunked pipeline-parallel prefill and tensor-parallel decode, composing under PD disaggregation to **2,808** tok/s per GPU.

The figure caption and alt text already reflect the new peak; only the TLDR was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)