### PR TITLE
Add online NVFP4 serving section to MXFP8/NVFP4 RL blog

### DIFF
--- a/blog/2026-07-29-mxfp8-nvfp4-rl.md
+++ b/blog/2026-07-29-mxfp8-nvfp4-rl.md
@@ -320,6 +320,16 @@ The training-side gap comes from the implementation used in this ablation, not a
 
 Beyond this ablation, [humans&](https://humansand.ai/) uses the same recipe family and components in production for large-scale, long-context, multi-agent asynchronous RL research.
 
+## Online NVFP4 Model Serving
+
+The same per-token NVFP4 recipe can serve FP8/BF16 model checkpoints with online post-training quantization (PTQ), delivering good model quality without calibration artifacts, while keeping compute performance on par with traditional NVFP4 serving.
+
+Online per-token activation scaling localizes activation outliers to each token and removes the need to carry static activation FP32 scales from a calibration pass. In FlashInfer, that FP32 scale computation is fused into the activation quantization kernel path, so online scaling does not require a separate preprocessing kernel.
+
+The post-training quantization (PTQ) model quality can be further improved by combining four-over-six with zero exposed decode latency, described in detail in the companion [humans&](https://humansand.ai/blog/nvfp4-rl) post.
+
+We implement and open-source this SGLang online NVFP4 serving path in [sglang#26083](https://github.com/sgl-project/sglang/pull/26083). Using this feature in SGLang is as simple as adding `--quantization nvfp4_online` to any existing BF16/FP8 MoE model serving commands.
+
 ## Future Work
 
 ### Dropping the extra BF16 weight copy


### PR DESCRIPTION
## Summary
@humansand

Add an **Online NVFP4 Model Serving** section to the published MXFP8/NVFP4 RL post.

The new section explains online PTQ for BF16/FP8 MoE checkpoints, fused per-token activation-scale computation in FlashInfer, optional four-over-six quality improvements, and SGLang usage through `--quantization nvfp4_online`.

## Testing

- `git diff --check`
- `node node_modules/next/dist/bin/next build`
