### PR TITLE
Fix Muse Glimmer Link

### DIFF
--- a/blog/2026-08-10-meta-muse-glimmer.md
+++ b/blog/2026-08-10-meta-muse-glimmer.md
@@ -6,7 +6,7 @@ previewImg: /images/blog/2026-08-10-meta-muse-glimmer/cover-muse-glimmer.png
 type: blog
 ---
 
-We're excited to partner with Meta Superintelligence Labs to bring Day-0 support for [Muse Glimmer](https://ai.meta.com/) to SGLang, with dedicated optimizations tailored for high-performance inference of agentic workflows on local hardware.
+We're excited to partner with Meta Superintelligence Labs to bring Day-0 support for [Muse Glimmer](https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model) to SGLang, with dedicated optimizations tailored for high-performance inference of agentic workflows on local hardware.
 
 ## Highlights
 


### PR DESCRIPTION
## Summary
- Point the "Muse Glimmer" hyperlink in the [Aug 10 blog post](https://www.lmsys.org/blog/2026-08-10-meta-muse-glimmer) to the official Meta research blog post (https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model) instead of the AI at Meta homepage.

## Test plan
- [x] Verified the link resolves to the correct Meta research blog post.