### PR TITLE
[Blog] Fix batch-8 throughput values in Muse Glimmer performance table

### DIFF
--- a/blog/2026-08-10-meta-muse-glimmer.md
+++ b/blog/2026-08-10-meta-muse-glimmer.md
@@ -55,14 +55,14 @@ We measured Muse Glimmer with SGLang across seven platforms, sweeping batch size
 
 | Platform | Precision | Decoding | tok/s/user (batch 1) | Output tok/s (batch 8) |
 | ----- | ----- | ----- | ----- | ----- |
-| NVIDIA B300 | bf16 | Standard | 91.77 | 21 |
-| NVIDIA B300 | bf16 | DFlash | 308.51 | 261 |
-| NVIDIA B300 | nvfp4 | Standard | 83.98 | 41 |
-| NVIDIA B300 | nvfp4 | DFlash | 290.01 | 295 |
+| NVIDIA B300 | bf16 | Standard | 91.77 | 721 |
+| NVIDIA B300 | bf16 | DFlash | 308.51 | 1261 |
+| NVIDIA B300 | nvfp4 | Standard | 83.98 | 841 |
+| NVIDIA B300 | nvfp4 | DFlash | 290.01 | 1295 |
 | NVIDIA RTX PRO 6000 | bf16 | Standard | 25.7 | 200 |
-| NVIDIA RTX PRO 6000 | bf16 | DFlash | 108.08 | 33 |
-| NVIDIA RTX PRO 6000 | nvfp4 | Standard | 58.04 | 51 |
-| NVIDIA RTX PRO 6000 | nvfp4 | DFlash | 214.11 | 403 |
+| NVIDIA RTX PRO 6000 | bf16 | DFlash | 108.08 | 833 |
+| NVIDIA RTX PRO 6000 | nvfp4 | Standard | 58.04 | 451 |
+| NVIDIA RTX PRO 6000 | nvfp4 | DFlash | 214.11 | 1403 |
 | NVIDIA DGX Spark | bf16 | Standard | 4.4 | 35 |
 | NVIDIA DGX Spark | bf16 | DFlash | 19.1 | 134 |
 | NVIDIA DGX Spark | nvfp4 | Standard | 12.1 | 92 |


### PR DESCRIPTION
Seven values in the `Output tok/s (batch 8)` column of the Muse Glimmer post (#388) had their leading digit dropped in transcription, understating throughput by roughly an order of magnitude. Corrected against the raw benchmark results.

| Row | Published | Corrected |
|---|---|---|
| B300 · bf16 · Standard | 21 | **721** |
| B300 · bf16 · DFlash | 261 | **1261** |
| B300 · nvfp4 · Standard | 41 | **841** |
| B300 · nvfp4 · DFlash | 295 | **1295** |
| RTX PRO 6000 · bf16 · DFlash | 33 | **833** |
| RTX PRO 6000 · nvfp4 · Standard | 51 | **451** |
| RTX PRO 6000 · nvfp4 · DFlash | 403 | **1403** |

One row per platform pair escaped because its truncated form would have looked obviously broken rather than plausible (`200.27` → `00.27`). The other 12 rows verify clean against their sweeps.

**Only the table changes.** The prose was already written from the correct figures and recomputes consistently against the fixed table:

- "batch-8 gain … ranging from 1.4x to 4.2x" → actual 1.44x–4.16x ✓
- "1.9-4.3x depending on platform and precision" → actual 1.94x–4.33x ✓
- "3.0x or better on every configuration except the GGUF path on RTX 5090" → holds for every row ✓

That the prose was right while the table was wrong points to the corruption happening during table transcription, not when the benchmarks were read.

**Sources:** B300 from `muse-bench/results/{A,B,C,D}.jsonl` (2026-08-10 sweep, `bench_one_batch_server`, 1k/1k, radix off, BS 1–8); RTX PRO 6000 from the corresponding platform sweep.

### Two follow-ups, not addressed here

1. **Batch-1 provenance.** Seven batch-1 values run consistently high by 0.02–0.08 against the runs I can source (B300 published 91.77 / 308.51 / 83.98 / 290.01 vs measured 91.69 / 308.49 / 83.93 / 289.95; RTX PRO 6000 108.08 / 58.04 / 214.11 vs 108.04 / 58.00 / 214.06). Too small to affect any claim in the post, but that column wasn't generated from those runs and I couldn't identify its source. Left unchanged pending confirmation from the benchmark owner.

2. **B300 methodology caveat.** The B300 DFlash rows ran KV `fp8_e4m3` at mem-fraction 0.80 with `--max-total-tokens 2000000`, while the Standard rows ran KV bf16 at mem-fraction 0.85 — so the DFlash speedup on that platform is confounded with a KV-cache dtype change. The workaround was needed to avoid a draft-KV-pool OOM at load, where the draft pool's bytes aren't deducted from the target pool budget. Probably deserves a footnote in the post and a separate upstream issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)