### PR TITLE
blog: refine Qwen3.8 chunked prefill section

### DIFF
--- a/blog/2026-08-12-qwen3-8-day0-support.md
+++ b/blog/2026-08-12-qwen3-8-day0-support.md
@@ -117,9 +117,10 @@ HiCache to compose with MTP and PD disaggregation.
 
 Decode and prefill favor different parallel layouts in the configurations measured
 here. For decode, we use wide expert parallelism to shard all 512 experts across ranks.
-At the measured 8K prefill operating points, the wide-EP configurations, which include
-dispatch and combine collectives, showed lower throughput than pure PP. PD
-disaggregation lets the two phases run on separate workers and use different layouts.
+Both wide-EP configurations below have EPLB enabled. At the measured 8K prefill
+operating points, the wide-EP configurations, which include dispatch and combine
+collectives, showed lower throughput than pure PP. PD disaggregation lets the two
+phases run on separate workers and use different layouts.
 
 With pure pipeline-parallel prefill, each stage owns a contiguous slice of the 92 layers
 and executes that slice on one rank, using full-width GEMMs without MoE dispatch,
@@ -127,7 +128,7 @@ combine, or EPLB. The main inter-stage communication is the activation transfer 
 stage boundary. Splitting a request into chunks allows the hand-off for chunk *i* to
 overlap the compute of chunk *i+1* as the chunks flow through the stages back to back.
 
-<img src="/images/blog/qwen3-8-day0-support/fig-chunked-pp-prefill.svg" alt="Chunked pipeline-parallel prefill: chunks flow through stages back to back, so each hand-off overlaps the next chunk's compute" width="720">
+<img src="/images/blog/qwen3-8-day0-support/fig-chunked-pp-prefill.svg" alt="Chunked pipeline-parallel prefill: chunks flow through stages back to back, so each hand-off overlaps the next chunk's compute" width="100%">
 
 Measured on 8K prefill at the operating points shown, in input tokens per second per GPU:
 
@@ -135,11 +136,6 @@ Measured on 8K prefill at the operating points shown, in input tokens per second
 |---|---:|---:|---:|
 | FP8, 16 GPUs | **5231** (PP16) | 3421 | **1.53×** |
 | NVFP4, 8 GPUs | **8363** (PP8) | 5151 | **1.62×** |
-
-The FP8 row comes from two dedicated prefill-only runs (8192 in, 1 out). The NVFP4 row
-reports the median prefill-batch rate observed during full 8192/1024 serving runs for
-each topology; this is distinct from end-to-end input throughput. Both wide-EP
-configurations have EPLB enabled.
 
 ### Pipeline-Parallel Prefill with MTP
 

--- a/public/images/blog/qwen3-8-day0-support/fig-chunked-pp-prefill.svg
+++ b/public/images/blog/qwen3-8-day0-support/fig-chunked-pp-prefill.svg
@@ -17,12 +17,14 @@
     </marker>
   </defs>
 
+  <g transform="translate(10 10)">
+
   <!-- ================= top: wide EP ================= -->
   <text class="ttl" x="0" y="14">Wide expert parallelism — one all-to-all pair per MoE layer</text>
   <text class="sub" x="0" y="30">every rank holds a slice of the 512 experts, so each layer must dispatch and combine</text>
 
   <line class="ax" x1="0" y1="96" x2="700" y2="96"/>
-  <text class="tiny" x="702" y="99">time</text>
+  <text class="tiny" x="698" y="92" text-anchor="end">time</text>
 
   <!-- layer 1 -->
   <rect class="cmp" x="0"   y="46" width="70" height="42" rx="2"/>
@@ -59,19 +61,19 @@
 
   <!-- axes -->
   <line class="ax" x1="66" y1="378" x2="700" y2="378"/>
-  <text class="tiny" x="702" y="381">time</text>
+  <text class="tiny" x="698" y="374" text-anchor="end">time</text>
 
   <!-- stage rows: 4 stages x 6 chunk slots, diagonal schedule -->
   <!-- row y positions -->
   <!-- stage 0 -->
-  <text class="lbl" x="60" y="216" text-anchor="end">stage 0</text>
-  <text class="tiny" x="60" y="228" text-anchor="end">layers 1–23</text>
-  <text class="lbl" x="60" y="256" text-anchor="end">stage 1</text>
-  <text class="tiny" x="60" y="268" text-anchor="end">layers 24–46</text>
-  <text class="lbl" x="60" y="296" text-anchor="end">stage 2</text>
-  <text class="tiny" x="60" y="308" text-anchor="end">layers 47–69</text>
-  <text class="lbl" x="60" y="336" text-anchor="end">stage 3</text>
-  <text class="tiny" x="60" y="348" text-anchor="end">layers 70–92</text>
+  <text class="lbl" x="66" y="216" text-anchor="end">stage 0</text>
+  <text class="tiny" x="66" y="228" text-anchor="end">layers 1–23</text>
+  <text class="lbl" x="66" y="256" text-anchor="end">stage 1</text>
+  <text class="tiny" x="66" y="268" text-anchor="end">layers 24–46</text>
+  <text class="lbl" x="66" y="296" text-anchor="end">stage 2</text>
+  <text class="tiny" x="66" y="308" text-anchor="end">layers 47–69</text>
+  <text class="lbl" x="66" y="336" text-anchor="end">stage 3</text>
+  <text class="tiny" x="66" y="348" text-anchor="end">layers 70–92</text>
 
   <!-- chunk blocks: c = chunk index, s = stage; x = 70 + (c+s)*96 -->
   <!-- stage 0: chunks 1..4 -->
@@ -109,4 +111,5 @@
   <path class="hand" d="M354,295 L356,318"/>
 
   <text class="tiny" x="70" y="398">the hand-off for chunk i overlaps the compute of chunk i+1 — the only wire traffic is one activation per boundary</text>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary

- render the chunked-prefill figure at the standard full article width
- keep the SVG labels inside the visible canvas and add balanced inner spacing
- state EPLB before the wide-EP comparison table
- remove the FP8/NVFP4 measurement-methodology note below the table

## Verification

- rendered the complete blog locally
- verified the chunked-prefill and 8K/1K figures use the same external width
- verified the left stage/layer labels and both right time labels are fully visible
- `xmllint --noout` on the SVG
- `git diff --check`