### PR TITLE
[Blog] Link Miles v0.1 to the GitHub repo in the intro

### DIFF
--- a/blog/2026-08-18-miles-v0-1.md
+++ b/blog/2026-08-18-miles-v0-1.md
@@ -5,7 +5,7 @@ date: "August 18, 2026"
 previewImg: "/images/blog/miles-v0-1/miles-logo.png"
 ---
 
-We present [Miles v0.1](https://github.com/radixark/miles), a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
+We present **[Miles v0.1](https://github.com/radixark/miles)**, a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
 
 ## The Miles RL Loop
 

--- a/blog/2026-08-18-miles-v0-1.md
+++ b/blog/2026-08-18-miles-v0-1.md
@@ -5,7 +5,7 @@ date: "August 18, 2026"
 previewImg: "/images/blog/miles-v0-1/miles-logo.png"
 ---
 
-We present [Miles v0.1](https://github.com/radixark/miles), a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
+We present [Miles](https://github.com/radixark/miles) v0.1, a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
 
 ## The Miles RL Loop
 

--- a/blog/2026-08-18-miles-v0-1.md
+++ b/blog/2026-08-18-miles-v0-1.md
@@ -5,7 +5,7 @@ date: "August 18, 2026"
 previewImg: "/images/blog/miles-v0-1/miles-logo.png"
 ---
 
-We present **[Miles v0.1](https://github.com/radixark/miles)**, a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
+We present [Miles v0.1](https://github.com/radixark/miles), a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
 
 ## The Miles RL Loop
 

--- a/blog/2026-08-18-miles-v0-1.md
+++ b/blog/2026-08-18-miles-v0-1.md
@@ -5,7 +5,7 @@ date: "August 18, 2026"
 previewImg: "/images/blog/miles-v0-1/miles-logo.png"
 ---
 
-We present Miles v0.1, a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
+We present [Miles v0.1](https://github.com/radixark/miles), a full-stack production-ready system for frontier post-training, the successor to our first Miles release [\[1\]](#ref-1). Building upon [slime](https://github.com/THUDM/slime)'s clean design, Miles optimizes every stage in the RL training loop around a simple principle: **verified, clean, and customizable everywhere**. With accuracy, efficiency, reliability, and scalability as first-class goals, Miles aims to make frontier-scale RL accessible to researchers and developers alike. In this blog post, we will walk through Miles end-to-end.
 
 ## The Miles RL Loop
 


### PR DESCRIPTION
In the Miles v0.1 post intro, link "Miles v0.1" to https://github.com/radixark/miles.