### PR TITLE
Update Hao Zhang website links

### DIFF
--- a/blog/2025-11-07-sglang-diffusion.md
+++ b/blog/2025-11-07-sglang-diffusion.md
@@ -218,7 +218,7 @@ Building this ecosystem is a community effort, and we welcome and encourage all 
 
 SGLang Diffusion Team: [Yuhao Yang](https://github.com/yhyang201), [Xinyuan Tong](https://github.com/JustinTong0323), [Yi Zhang](https://github.com/yizhang2077), [Ke Bao](https://github.com/ispobock), [Ji Li](https://github.com/GeLee-Q/GeLee-Q), [Xi Chen](https://github.com/RubiaCx), [Laixin Xie](https://github.com/laixinn), [Yikai Zhu](https://github.com/zyksir), [Mick](https://mickqian.github.io)
 
-FastVideo Team: [Peiyuan Zhang](https://github.com/jzhang38), [William Lin](https://github.com/SolitaryThinker), [Yongqi Chen](https://github.com/BrianChen1129), [Kevin Lin](https://github.com/kevin314), [Wenxuan Tan](https://github.com/Edenzzzz), [Wei Zhou](https://github.com/JerryZhou54), [Runlong Su](https://github.com/rlsu9), [Jinzhe Pan](https://github.com/Eigensystem), [Hangliang Ding](https://github.com/foreverpiano), [Matthew Noto](https://github.com/RandNMR73), [You Zhou](https://github.com/PorridgeSwim), [Jiali Chen](https://github.com/Gary-ChenJL), [Hao Zhang](https://cseweb.ucsd.edu/~haozhang/)
+FastVideo Team: [Peiyuan Zhang](https://github.com/jzhang38), [William Lin](https://github.com/SolitaryThinker), [Yongqi Chen](https://github.com/BrianChen1129), [Kevin Lin](https://github.com/kevin314), [Wenxuan Tan](https://github.com/Edenzzzz), [Wei Zhou](https://github.com/JerryZhou54), [Runlong Su](https://github.com/rlsu9), [Jinzhe Pan](https://github.com/Eigensystem), [Hangliang Ding](https://github.com/foreverpiano), [Matthew Noto](https://github.com/RandNMR73), [You Zhou](https://github.com/PorridgeSwim), [Jiali Chen](https://github.com/Gary-ChenJL), [Hao Zhang](https://haozhang.ai/)
 
 Special thanks to NVIDIA and Voltage Park for their compute support.
 

--- a/content/about.md
+++ b/content/about.md
@@ -44,7 +44,7 @@ More information see [FlashInfer GitHub](https://github.com/flashinfer-ai/flashi
 [Ion Stoica](https://people.eecs.berkeley.edu/~istoica/),
 [Zhanghao Wu](https://zhanghaowu.me),
 [Eric P. Xing](http://www.cs.cmu.edu/~epxing/),
-[Hao Zhang](https://people.eecs.berkeley.edu/~hao/),
+[Hao Zhang](https://haozhang.ai/),
 [Lianmin Zheng](https://lmzheng.net/),
 [Siyuan Zhuang](https://github.com/suquark),
 [Yonghao Zhuang](https://github.com/ZYHowell)
@@ -53,7 +53,7 @@ More information see [FlashInfer GitHub](https://github.com/flashinfer-ai/flashi
 Project memberships are granted to individuals who have demonstrated outstanding technical contributions and research impact in LMSYS projects, as evaluated by our advisory board of distinguished academics and industry leaders.
 
 ## Advisors
-[Joseph E. Gonzalez](https://people.eecs.berkeley.edu/~jegonzal/), [Ion Stoica](https://people.eecs.berkeley.edu/~istoica/), [Eric P. Xing](http://www.cs.cmu.edu/~epxing/), [Hao Zhang](https://people.eecs.berkeley.edu/~hao/), [Jun Qian](https://www.linkedin.com/in/junqian1/), [Mingxing Zhang](https://madsys.cs.tsinghua.edu.cn/~zhangmx/)
+[Joseph E. Gonzalez](https://people.eecs.berkeley.edu/~jegonzal/), [Ion Stoica](https://people.eecs.berkeley.edu/~istoica/), [Eric P. Xing](http://www.cs.cmu.edu/~epxing/), [Hao Zhang](https://haozhang.ai/), [Jun Qian](https://www.linkedin.com/in/junqian1/), [Mingxing Zhang](https://madsys.cs.tsinghua.edu.cn/~zhangmx/)
 
 ## Sponsors
 LMSYS is supported by donations from the following institutions:


### PR DESCRIPTION
Update Hao Zhang's personal website links to https://haozhang.ai/ in the About page's Vicuna member and advisor lists and the SGLang Diffusion blog's FastVideo acknowledgments. The old Berkeley homepage returns HTTP 404.

Validation: confirmed the new homepage returns HTTP 200, checked all three replacements and searched `content/` and `blog/` for remaining references to the old Berkeley and UCSD homepage URLs. `git diff --check` passes. A full site build was not run for this URL-only change.

Deployment note: the live https://www.lmsys.org/about page is served by Vercel and has different content from this repository's About page, while this repository's workflow deploys to GitHub Pages. Please verify whether the live About page uses this source or needs the same link update separately.
